### PR TITLE
chore: Add `HttpClient` Type

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -2,7 +2,10 @@ use hyper::Client;
 use hyper_rustls::HttpsConnector;
 use tokio_vsock::VsockAddr;
 
-use crate::utils::http::{VSockClientBuilder, vsock_proxy};
+use crate::utils::http::vsock_proxy;
+
+// Re-export VSockClientBuilder for public use
+pub use crate::utils::http::VSockClientBuilder;
 
 /// The CID of the vsock proxy.
 pub const VSOCK_PROXY_CID: u32 = 3;

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -21,6 +21,11 @@ pub fn vsock_proxy(address: VsockAddr) -> HttpsConnector<VSockClientBuilder> {
 	HttpsConnector::from((VSockClientBuilder { address }, cc))
 }
 
+/// A connector builder for creating vsock-based HTTP(S) connections.
+///
+/// This type implements hyper's `Service` trait to create connections through
+/// a vsock address, typically used for communication with the host from within
+/// a Nitro Enclave.
 #[derive(Debug, Clone, Copy)]
 pub struct VSockClientBuilder {
 	address: VsockAddr,


### PR DESCRIPTION
Added a type for the http client, previously it was **improssible** to use it because it was relying in a private `VSockClientBuilder` type.