### PR TITLE
feat: Remove Arc by default states

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ struct AppState {
     db: Database,
 }
 
-let router = Router::with_state(AppState { db: Database::new() })
+// ⚠️ Warning: Remember to wrap expensive states with Arc
+let router = Router::with_state(Arc::new(AppState { db: Database::new() }))
     .route::<GetUser, _, _>(|state: Arc<AppState>, req| async move {
         // Handlers receive Arc<State> for cheap cloning
         state.db.get_user(req.id).await


### PR DESCRIPTION
This PR removes default wrapping router states with `Arc` pointer. This design had good intentions but was limiting some cases where the State `<S>` didn't implement copy trait and forcing the user to use double Arc pointers 