### PR TITLE
ci: Fix CI by adding toolchain componenents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches: [main]
     pull_request:
+      branches: [main]
 
 env:
     CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,72 +1,72 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+    push:
+        branches: [main]
+    pull_request:
 
 env:
-  CARGO_TERM_COLOR: always
+    CARGO_TERM_COLOR: always
 
 jobs:
-  lint:
-    name: Format, Clippy & Build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    lint:
+        name: Format, Clippy & Build
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
+            - uses: dtolnay/rust-toolchain@stable
+              with:
+                components: clippy, rustfmt
 
-      - name: Check code formatting
-        run: cargo fmt -- --check
+            - name: Check code formatting
+              run: cargo fmt -- --check
 
-      - name: Run clippy
-        run: cargo clippy --all-targets --all-features
+            - name: Run clippy
+              run: cargo clippy --all-targets --all-features
 
-      - name: Build
-        run: cargo build
+            - name: Build
+              run: cargo build
 
-  test:
-    name: Tests
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    test:
+        name: Tests
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+            - uses: dtolnay/rust-toolchain@stable
 
-      - name: Run tests
-        run: |
-          cargo test --all-features
+            - name: Run tests
+              run: |
+                  cargo test --all-features
 
-  deny:
-    name: Cargo deny
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      matrix:
-        checks:
-          - advisories
-          - bans licenses sources
+    deny:
+        name: Cargo deny
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        strategy:
+            matrix:
+                checks:
+                    - advisories
+                    - bans licenses sources
 
-    continue-on-error: ${{ matrix.checks == 'advisories' }}
+        continue-on-error: ${{ matrix.checks == 'advisories' }}
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
 
-      - uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          command: check ${{ matrix.checks }}
-          rust-version: stable
-          arguments: --all-features
+            - uses: EmbarkStudios/cargo-deny-action@v2
+              with:
+                  command: check ${{ matrix.checks }}
+                  rust-version: stable
+                  arguments: --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,75 +1,73 @@
 name: CI
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-      branches: [main]
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
-    CARGO_TERM_COLOR: always
+  CARGO_TERM_COLOR: always
 
 jobs:
-    lint:
-        name: Format, Clippy & Build
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
+  lint:
+    name: Format, Clippy & Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - uses: dtolnay/rust-toolchain@stable
-              with:
-                  toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
 
-            - name: Check code formatting
-              run: cargo fmt -- --check
+      - name: Check code formatting
+        run: cargo fmt -- --check
 
-            - name: Run clippy
-              run: cargo clippy --all-targets --all-features
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features
 
-            - name: Build
-              run: cargo build
+      - name: Build
+        run: cargo build
 
-    test:
-        name: Tests
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - uses: dtolnay/rust-toolchain@master
-              with:
-                  toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
 
-            - name: Run tests
-              run: |
-                  cargo test --all-features
+      - name: Run tests
+        run: |
+          cargo test --all-features
 
-    deny:
-        name: Cargo deny
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        strategy:
-            matrix:
-                checks:
-                    - advisories
-                    - bans licenses sources
+  deny:
+    name: Cargo deny
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        checks:
+          - advisories
+          - bans licenses sources
 
-        continue-on-error: ${{ matrix.checks == 'advisories' }}
+    continue-on-error: ${{ matrix.checks == 'advisories' }}
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - uses: EmbarkStudios/cargo-deny-action@v2
-              with:
-                  command: check ${{ matrix.checks }}
-                  rust-version: stable
-                  arguments: --all-features
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check ${{ matrix.checks }}
+          rust-version: stable
+          arguments: --all-features


### PR DESCRIPTION
CI was failing due to the missing `cargo-fmt` component. Changed the toolchain step to follow conventions from other repos. 

Source: https://github.com/dtolnay/rust-toolchain/tree/master?tab=readme-ov-file#inputs