### PR TITLE
fix: drop unmaintained rustls-pemfile from the dependency tree

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,11 @@
+{
+  "lsp": {
+    "rust-analyzer": {
+      "initialization_options": {
+        "cargo": {
+          "features": "all",
+        },
+      },
+    },
+  },
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,22 @@ nsm-types = [
     "dep:aws-nitro-enclaves-cose",
     "dep:aws-nitro-enclaves-nsm-api",
 ]
-http = ["dep:hyper", "dep:rustls", "dep:hyper-rustls"]
+http = ["_vsock-https"]
 kms = [
-    "dep:hyper",
-    "dep:rustls",
+    "_vsock-https",
     "dep:aws-types",
     "dep:aws-sdk-kms",
-    "dep:hyper-rustls",
+    "dep:aws-smithy-types",
     "dep:aws-smithy-runtime-api",
-    "dep:aws-smithy-http-client",
+]
+# The HTTPS-over-vsock transport, shared by `http` and `kms`.
+_vsock-https = [
+    "dep:hyper",
+    "dep:rustls",
+    "dep:hyper-util",
+    "dep:hyper-rustls",
+    "dep:tower-service",
+    "tokio/time",
 ]
 
 [package.metadata.docs.rs]
@@ -47,29 +54,39 @@ rmp-serde = "1"
 thiserror = "2"
 tokio-vsock = "0.7"
 sha2 = { version = "0.10", optional = true }
-rustls = { version = "0.22", optional = true }
 aws-types = { version = "1", optional = true }
 tokio = { version = "1", features = ["io-util"] }
 serde_bytes = { version = "0.11", optional = true }
-aws-sdk-kms = { version = "1.72.0", optional = true }
+tower-service = { version = "0.3", optional = true }
+hyper = { version = "1.7", features = ["client"], optional = true }
 serde_cbor = { version = "0.11", default-features = false, optional = true }
-# `default-features = false` drops `native-tokio`, which pulls in `rustls-native-certs` and with it
-# the unmaintained `rustls-pemfile` (RUSTSEC-2025-0134). The vsock client trusts the webpki roots
-# (see `utils::http`), so the native certificate store is never read.
-hyper-rustls = { version = "0.25.0", optional = true, default-features = false, features = [
-    "webpki-roots",
-    "tokio-runtime",
+aws-smithy-types = { version = "1.3", features = ["http-body-1-x"], optional = true }
+aws-nitro-enclaves-cose = { version = "0.5", optional = true, default-features = false }
+aws-nitro-enclaves-nsm-api = { version = "0.4", optional = true, default-features = false }
+aws-smithy-runtime-api = { version = "1.9", features = ["client", "http-1x"], optional = true }
+aws-sdk-kms = { version = "1.72.0", optional = true, default-features = false, features = [
+    "rt-tokio",
+] }
+hyper-util = { version = "0.1.20", optional = true, default-features = false, features = [
+    "client-legacy",
     "http1",
     "http2",
-    "tls12",
+    "tokio",
+] }
+hyper-rustls = { version = "0.27.9", optional = true, default-features = false, features = [
+    "http1",
+    "http2",
     "logging",
     "ring",
+    "tls12",
+    "webpki-tokio",
 ] }
-aws-smithy-runtime-api = { version = "1.8.0", features = ["client"], optional = true }
-hyper = { version = "0.14", features = ["client", "http1", "http2"], optional = true }
-aws-nitro-enclaves-cose = { version = "0.5", optional = true, default-features = false }
-aws-smithy-http-client = { version = "1.0.2", features = ["hyper-014"], optional = true }
-aws-nitro-enclaves-nsm-api = { version = "0.4", optional = true, default-features = false }
+rustls = { version = "0.23", optional = true, default-features = false, features = [
+    "logging",
+    "ring",
+    "std",
+    "tls12",
+] }
 const-fnv1a-hash = "1.1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,18 @@ tokio = { version = "1", features = ["io-util"] }
 serde_bytes = { version = "0.11", optional = true }
 aws-sdk-kms = { version = "1.72.0", optional = true }
 serde_cbor = { version = "0.11", default-features = false, optional = true }
-hyper-rustls = { version = "0.25.0", optional = true, features = ["webpki-roots"] }
+# `default-features = false` drops `native-tokio`, which pulls in `rustls-native-certs` and with it
+# the unmaintained `rustls-pemfile` (RUSTSEC-2025-0134). The vsock client trusts the webpki roots
+# (see `utils::http`), so the native certificate store is never read.
+hyper-rustls = { version = "0.25.0", optional = true, default-features = false, features = [
+    "webpki-roots",
+    "tokio-runtime",
+    "http1",
+    "http2",
+    "tls12",
+    "logging",
+    "ring",
+] }
 aws-smithy-runtime-api = { version = "1.8.0", features = ["client"], optional = true }
 hyper = { version = "0.14", features = ["client", "http1", "http2"], optional = true }
 aws-nitro-enclaves-cose = { version = "0.5", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,3 +91,5 @@ const-fnv1a-hash = "1.1.0"
 
 [dev-dependencies]
 tokio-test = "0.4"
+tokio = { version = "1", features = ["macros", "rt", "test-util", "time"] }
+aws-smithy-runtime-api = { version = "1.9", features = ["client", "http-1x", "test-util"] }

--- a/deny.toml
+++ b/deny.toml
@@ -39,6 +39,25 @@ allow = [
 # Ignore unmaintained required crates warning
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0436", # Unmaintained `paste` (2025-08-07)
     "RUSTSEC-2021-0127", # Unmaintained `serde_cbor` (requires upstream update, see https://github.com/aws/aws-nitro-enclaves-nsm-api/pull/56)
 ]
+
+# Known-failing advisories, deliberately NOT ignored so they stay visible:
+#
+#   RUSTSEC-2026-0258                     h2 0.3.x        (no fix on the 0.3 line, patched in 0.4.16)
+#   RUSTSEC-2026-0098/-0099/-0104         rustls-webpki 0.101.7 via rustls 0.21
+#   RUSTSEC-2026-0049/-0098/-0099/-0104   rustls-webpki 0.102.8 via rustls 0.22
+#
+# All of them are downstream of the `hyper 0.14` pin and cannot be resolved by bumping versions:
+#
+#   - `hyper-rustls` 0.26+ requires hyper 1.x, and `rustls` 0.22 is the newest release
+#     `hyper-rustls` 0.25 accepts, so `rustls-webpki` cannot move past 0.102 while we are on
+#     hyper 0.14.
+#   - `aws-smithy-http-client`'s `hyper-014` feature brings its own hyper 0.14 + rustls 0.21 +
+#     h2 0.3. Its hyper-1 (`default-client`) path exposes no public API for supplying a custom
+#     transport connector — `hyper_014::HyperClientBuilder::build(connector)` is the only entry
+#     point that takes one — so `kms` cannot switch without implementing
+#     `aws_smithy_runtime_api::client::http::HttpClient` here.
+#
+# Fixing them therefore means migrating the vsock transport to hyper 1.x + hyper-util, which
+# changes the public `http::HttpClient` type.

--- a/deny.toml
+++ b/deny.toml
@@ -41,23 +41,3 @@ allow = [
 ignore = [
     "RUSTSEC-2021-0127", # Unmaintained `serde_cbor` (requires upstream update, see https://github.com/aws/aws-nitro-enclaves-nsm-api/pull/56)
 ]
-
-# Known-failing advisories, deliberately NOT ignored so they stay visible:
-#
-#   RUSTSEC-2026-0258                     h2 0.3.x        (no fix on the 0.3 line, patched in 0.4.16)
-#   RUSTSEC-2026-0098/-0099/-0104         rustls-webpki 0.101.7 via rustls 0.21
-#   RUSTSEC-2026-0049/-0098/-0099/-0104   rustls-webpki 0.102.8 via rustls 0.22
-#
-# All of them are downstream of the `hyper 0.14` pin and cannot be resolved by bumping versions:
-#
-#   - `hyper-rustls` 0.26+ requires hyper 1.x, and `rustls` 0.22 is the newest release
-#     `hyper-rustls` 0.25 accepts, so `rustls-webpki` cannot move past 0.102 while we are on
-#     hyper 0.14.
-#   - `aws-smithy-http-client`'s `hyper-014` feature brings its own hyper 0.14 + rustls 0.21 +
-#     h2 0.3. Its hyper-1 (`default-client`) path exposes no public API for supplying a custom
-#     transport connector — `hyper_014::HyperClientBuilder::build(connector)` is the only entry
-#     point that takes one — so `kms` cannot switch without implementing
-#     `aws_smithy_runtime_api::client::http::HttpClient` here.
-#
-# Fixing them therefore means migrating the vsock transport to hyper 1.x + hyper-util, which
-# changes the public `http::HttpClient` type.

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,8 +10,8 @@ use tokio_vsock::VsockAddr;
 
 use crate::utils::http::vsock_proxy_http2;
 
-// Re-export VSockClientBuilder for public use
-pub use crate::utils::http::VSockClientBuilder;
+// Both appear in `HttpClient`, so callers need to be able to name them.
+pub use crate::utils::http::{ConnectTimeout, VSockClientBuilder};
 
 /// The CID of the vsock proxy.
 pub const VSOCK_PROXY_CID: u32 = 3;
@@ -19,7 +19,7 @@ pub const VSOCK_PROXY_CID: u32 = 3;
 /// A HTTP client that tunnels all requests through the host's vsock proxy.
 ///
 /// `B` is the request body, e.g. `http_body_util::Full<bytes::Bytes>`.
-pub type HttpClient<B> = Client<HttpsConnector<VSockClientBuilder>, B>;
+pub type HttpClient<B> = Client<ConnectTimeout<HttpsConnector<VSockClientBuilder>>, B>;
 
 #[must_use]
 /// Creates an HTTPS client that tunnels all requests through the host's vsock proxy.
@@ -81,12 +81,24 @@ where
 }
 
 /// Configuration for an HTTPS client that tunnels all requests through the host's vsock proxy and only uses HTTP/2.
+///
+/// Build from [`Default`] and adjust what you need; the struct is `non_exhaustive` so that adding a
+/// knob later is not a breaking change.
+#[non_exhaustive]
 pub struct Http2ClientConfig {
-	initial_stream_window_size: Option<u32>,
-	initial_connection_window_size: Option<u32>,
-	adaptive_window: bool,
-	keep_alive_interval: Option<Duration>,
-	keep_alive_timeout: Duration,
+	/// Initial HTTP/2 stream window size. `None` leaves hyper's default in place.
+	pub initial_stream_window_size: Option<u32>,
+	/// Initial HTTP/2 connection window size. `None` leaves hyper's default in place.
+	pub initial_connection_window_size: Option<u32>,
+	/// Whether to let hyper grow the flow-control windows in response to throughput.
+	pub adaptive_window: bool,
+	/// How often to send an HTTP/2 keep-alive ping. `None` disables them.
+	pub keep_alive_interval: Option<Duration>,
+	/// How long to wait for a keep-alive ping response before dropping the connection.
+	pub keep_alive_timeout: Duration,
+	/// Bounds the vsock dial and the TLS handshake together. `None` leaves them unbounded, which
+	/// lets a proxy that accepts the connection and then stalls hang the request forever.
+	pub connect_timeout: Option<Duration>,
 }
 
 impl Default for Http2ClientConfig {
@@ -98,6 +110,7 @@ impl Default for Http2ClientConfig {
 			keep_alive_interval: None,
 			// Hyper's default is 20 seconds
 			keep_alive_timeout: Duration::from_secs(20),
+			connect_timeout: Some(Duration::from_secs(10)),
 		}
 	}
 }
@@ -123,8 +136,8 @@ where
 		.http2_initial_stream_window_size(config.initial_stream_window_size)
 		.http2_initial_connection_window_size(config.initial_connection_window_size);
 
-	builder.build(vsock_proxy_http2(VsockAddr::new(
-		VSOCK_PROXY_CID,
-		vsock_proxy_port,
-	)))
+	builder.build(vsock_proxy_http2(
+		VsockAddr::new(VSOCK_PROXY_CID, vsock_proxy_port),
+		config.connect_timeout,
+	))
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,10 +1,14 @@
 use std::time::Duration;
 
-use hyper::Client;
+use hyper::body::Body;
 use hyper_rustls::HttpsConnector;
+use hyper_util::{
+	client::legacy::Client,
+	rt::{TokioExecutor, TokioTimer},
+};
 use tokio_vsock::VsockAddr;
 
-use crate::utils::http::{vsock_proxy, vsock_proxy_http2_only};
+use crate::utils::http::vsock_proxy_http2;
 
 // Re-export VSockClientBuilder for public use
 pub use crate::utils::http::VSockClientBuilder;
@@ -13,7 +17,9 @@ pub use crate::utils::http::VSockClientBuilder;
 pub const VSOCK_PROXY_CID: u32 = 3;
 
 /// A HTTP client that tunnels all requests through the host's vsock proxy.
-pub type HttpClient = Client<HttpsConnector<VSockClientBuilder>>;
+///
+/// `B` is the request body, e.g. `http_body_util::Full<bytes::Bytes>`.
+pub type HttpClient<B> = Client<HttpsConnector<VSockClientBuilder>, B>;
 
 #[must_use]
 /// Creates an HTTPS client that tunnels all requests through the host's vsock proxy.
@@ -30,21 +36,23 @@ pub type HttpClient = Client<HttpsConnector<VSockClientBuilder>>;
 ///
 /// Example usage (generic HTTPS request):
 /// ```rust,ignore
-/// use hyper::{Client, Request, Body, body::to_bytes};
-/// use pontifex::http;
+/// use bytes::Bytes;
+/// use http_body_util::{BodyExt, Full};
+/// use hyper::Request;
+/// use pontifex::http::{self, HttpClient};
 ///
 /// #[tokio::main]
 /// async fn main() -> anyhow::Result<()> {
 ///     // The port where your host's vsock proxy listens
-///     let client: Client<_> = http::client(8000);
+///     let client: HttpClient<Full<Bytes>> = http::client(8000);
 ///
 ///     let req = Request::builder()
 ///         .method("GET")
 ///         .uri("https://api.example.com/v1/ping")
-///         .body(Body::empty())?;
+///         .body(Full::default())?;
 ///
 ///     let res = client.request(req).await?;
-///     let body = to_bytes(res).await?;
+///     let body = res.into_body().collect().await?.to_bytes();
 ///     println!("{}", String::from_utf8_lossy(&body));
 ///     Ok(())
 /// }
@@ -57,16 +65,19 @@ pub type HttpClient = Client<HttpsConnector<VSockClientBuilder>>;
 /// - The connector ignores the dial target from the URI and always connects to
 ///   the fixed vsock address (CID 3 + `vsock_proxy_port`), while preserving
 ///   Host/SNI for end-to-end TLS to the upstream.
-pub fn client(vsock_proxy_port: u32) -> HttpClient {
-	Client::builder()
-		.http2_only(true)
-		.http2_adaptive_window(false)  // Prevent large window updates
-		.http2_keep_alive_interval(Some(Duration::from_secs(30)))
-		.http2_keep_alive_timeout(Duration::from_secs(10))
-		.build(vsock_proxy(VsockAddr::new(
-			VSOCK_PROXY_CID,
-			vsock_proxy_port,
-		)))
+pub fn client<B>(vsock_proxy_port: u32) -> HttpClient<B>
+where
+	B: Body + Send,
+	B::Data: Send,
+{
+	client_http2_only(
+		vsock_proxy_port,
+		&Http2ClientConfig {
+			keep_alive_interval: Some(Duration::from_secs(30)),
+			keep_alive_timeout: Duration::from_secs(10),
+			..Http2ClientConfig::default()
+		},
+	)
 }
 
 /// Configuration for an HTTPS client that tunnels all requests through the host's vsock proxy and only uses HTTP/2.
@@ -93,16 +104,27 @@ impl Default for Http2ClientConfig {
 
 /// Creates an HTTPS client that tunnels all requests through the host's vsock proxy and only uses HTTP/2.
 #[must_use]
-pub fn client_http2_only(vsock_proxy_port: u32, config: &Http2ClientConfig) -> HttpClient {
-	Client::builder()
+pub fn client_http2_only<B>(vsock_proxy_port: u32, config: &Http2ClientConfig) -> HttpClient<B>
+where
+	B: Body + Send,
+	B::Data: Send,
+{
+	let mut builder = Client::builder(TokioExecutor::new());
+
+	builder
+		// Unlike hyper 0.14, hyper-util does not install a timer of its own, and silently drops
+		// keep-alives and pool idle timeouts without one.
+		.timer(TokioTimer::new())
+		.pool_timer(TokioTimer::new())
 		.http2_only(true)
 		.http2_adaptive_window(config.adaptive_window)
 		.http2_keep_alive_interval(config.keep_alive_interval)
 		.http2_keep_alive_timeout(config.keep_alive_timeout)
 		.http2_initial_stream_window_size(config.initial_stream_window_size)
-		.http2_initial_connection_window_size(config.initial_connection_window_size)
-		.build(vsock_proxy_http2_only(VsockAddr::new(
-			VSOCK_PROXY_CID,
-			vsock_proxy_port,
-		)))
+		.http2_initial_connection_window_size(config.initial_connection_window_size);
+
+	builder.build(vsock_proxy_http2(VsockAddr::new(
+		VSOCK_PROXY_CID,
+		vsock_proxy_port,
+	)))
 }

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -113,11 +113,14 @@ fn bounded_timeouts(configured: Option<&TimeoutConfig>) -> TimeoutConfig {
 		.build()
 }
 
-/// The connect and read timeouts in force for a request. Always bounded.
+/// The connect and read timeouts the orchestrator resolved for a request.
+///
+/// `None` means the caller disabled it. `kms::client` fills in defaults for anything merely unset,
+/// so nothing is re-defaulted here: doing that again would override an explicit `disabled()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct Timeouts {
-	connect: Duration,
-	read: Duration,
+	connect: Option<Duration>,
+	read: Option<Duration>,
 }
 
 /// Idle connections one connector keeps per upstream authority. hyper-util's default is unbounded,
@@ -165,43 +168,36 @@ impl HttpClient for VSockHttpClient {
 		settings: &HttpConnectorSettings,
 		_: &RuntimeComponents,
 	) -> SharedHttpConnector {
-		// An explicit setting always wins; the default only fills a gap.
 		let timeouts = Timeouts {
-			connect: settings
-				.connect_timeout()
-				.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
-			read: settings.read_timeout().unwrap_or(DEFAULT_READ_TIMEOUT),
+			connect: settings.connect_timeout(),
+			read: settings.read_timeout(),
 		};
 
-		let cacheable = {
-			let connectors = self
-				.connectors
-				.read()
-				.unwrap_or_else(PoisonError::into_inner);
-
-			if let Some(connector) = connectors.get(&timeouts) {
-				return connector.clone();
-			}
-
-			connectors.len() < MAX_CACHED_CONNECTORS
-		};
+		if let Some(connector) = self
+			.connectors
+			.read()
+			.unwrap_or_else(PoisonError::into_inner)
+			.get(&timeouts)
+		{
+			return connector.clone();
+		}
 
 		// Built before taking the write lock: this constructs a rustls `ClientConfig`, and holding
 		// an exclusive lock across that would serialize every concurrent KMS call behind it.
 		let connector = SharedHttpConnector::new(VSockConnector::new(self.address, timeouts));
+		let mut connectors = self
+			.connectors
+			.write()
+			.unwrap_or_else(PoisonError::into_inner);
 
-		if !cacheable {
+		if connectors.len() >= MAX_CACHED_CONNECTORS && !connectors.contains_key(&timeouts) {
+			drop(connectors);
 			self.warn_cache_full();
 
 			return connector;
 		}
 
-		self.connectors
-			.write()
-			.unwrap_or_else(PoisonError::into_inner)
-			.entry(timeouts)
-			.or_insert(connector)
-			.clone()
+		connectors.entry(timeouts).or_insert(connector).clone()
 	}
 
 	fn connector_metadata(&self) -> Option<ConnectorMetadata> {
@@ -215,7 +211,7 @@ impl HttpClient for VSockHttpClient {
 #[derive(Debug)]
 struct VSockConnector {
 	client: Client<ConnectTimeout<HttpsConnector<VSockClientBuilder>>, SdkBody>,
-	read_timeout: Duration,
+	read_timeout: Option<Duration>,
 }
 
 #[cfg(test)]
@@ -271,15 +267,19 @@ impl HttpConnector for VSockConnector {
 async fn await_headers<B>(
 	response: impl Future<Output = Result<hyper::Response<B>, hyper_util::client::legacy::Error>>,
 	target: &hyper::Uri,
-	read_timeout: Duration,
+	read_timeout: Option<Duration>,
 ) -> Result<hyper::Response<B>, ConnectorError> {
-	tokio::time::timeout(read_timeout, response)
-		.await
-		.map_err(|_| read_timed_out(target, read_timeout))?
-		.map_err(|err| {
-			let is_connect = err.is_connect();
-			classify_error(err, is_connect)
-		})
+	let headers = match read_timeout {
+		Some(timeout) => tokio::time::timeout(timeout, response)
+			.await
+			.map_err(|_| read_timed_out(target, timeout))?,
+		None => response.await,
+	};
+
+	headers.map_err(|err| {
+		let is_connect = err.is_connect();
+		classify_error(err, is_connect)
+	})
 }
 
 /// Addresses are left unset: a vsock peer has no socket address, and nothing on this path
@@ -460,7 +460,7 @@ mod tests {
 		let err = await_headers(
 			never,
 			&hyper::Uri::from_static("https://kms.eu-west-1.amazonaws.com"),
-			Duration::from_secs(5),
+			Some(Duration::from_secs(5)),
 		)
 		.await
 		.expect_err("headers that never arrive must time out");
@@ -534,6 +534,50 @@ mod tests {
 		let err = classify_error(Opaque, false);
 
 		assert!(err.is_other(), "got {err:?}");
+	}
+
+	#[test]
+	fn an_unset_timeout_reaches_the_connector_unset() {
+		use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+
+		let client = VSockHttpClient::new(VsockAddr::new(VSOCK_PROXY_CID, 8000));
+		let components = RuntimeComponentsBuilder::for_tests().build().unwrap();
+
+		counting_connectors(|| {
+			client.http_connector(&HttpConnectorSettings::builder().build(), &components);
+		});
+
+		let timeouts = {
+			let connectors = client
+				.connectors
+				.read()
+				.unwrap_or_else(PoisonError::into_inner);
+
+			*connectors.keys().next().expect("one connector")
+		};
+
+		assert_eq!(timeouts.connect, None, "not ours to fill in here");
+		assert_eq!(timeouts.read, None, "not ours to fill in here");
+	}
+
+	#[test]
+	fn the_two_timeouts_are_not_transposed() {
+		let mut connector = None;
+
+		counting_connectors(|| {
+			connector = Some(VSockConnector::new(
+				VsockAddr::new(VSOCK_PROXY_CID, 8000),
+				Timeouts {
+					connect: Some(Duration::from_secs(3)),
+					read: Some(Duration::from_secs(17)),
+				},
+			));
+		});
+
+		assert_eq!(
+			connector.expect("built").read_timeout,
+			Some(Duration::from_secs(17))
+		);
 	}
 
 	/// `CONNECTORS_BUILT` is process-wide, so every test that can build a connector has to go

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -1,13 +1,19 @@
 use std::{
+	borrow::Cow,
 	collections::HashMap,
 	error::Error,
 	io,
-	sync::{PoisonError, RwLock},
+	sync::{
+		PoisonError, RwLock,
+		atomic::{AtomicBool, Ordering},
+	},
 	time::Duration,
 };
 
 use aws_sdk_kms::config::SharedCredentialsProvider;
 use aws_smithy_runtime_api::client::{
+	connection::{CaptureSmithyConnection, ConnectionMetadata},
+	connector_metadata::ConnectorMetadata,
 	http::{
 		HttpClient, HttpConnector, HttpConnectorFuture, HttpConnectorSettings, SharedHttpConnector,
 	},
@@ -15,19 +21,29 @@ use aws_smithy_runtime_api::client::{
 	result::ConnectorError,
 	runtime_components::RuntimeComponents,
 };
-use aws_smithy_types::body::SdkBody;
+use aws_smithy_types::{body::SdkBody, timeout::TimeoutConfig};
 use aws_types::SdkConfig;
 use hyper_rustls::HttpsConnector;
 use hyper_util::{
-	client::legacy::Client,
+	client::legacy::{
+		Client,
+		connect::{CaptureConnection, capture_connection},
+	},
 	rt::{TokioExecutor, TokioTimer},
 };
 use tokio_vsock::VsockAddr;
 
-use crate::utils::http::{VSockClientBuilder, vsock_proxy_http1};
+use crate::utils::http::{ConnectTimeout, VSockClientBuilder, vsock_proxy_http1};
 
 /// The CID of the vsock proxy.
 pub const VSOCK_PROXY_CID: u32 = 3;
+
+/// Applied when the caller's `SdkConfig` carries no timeout of its own. Connection timeout.
+const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(4);
+/// Timeout on reading the response headers.
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
+/// Bounds one attempt end to end.
+const DEFAULT_ATTEMPT_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// Credentials to use for KMS requests.
 pub struct Credentials {
@@ -51,7 +67,11 @@ impl Credentials {
 	}
 }
 
-/// Creates a new KMS client.
+/// Creates a new KMS client. Re-uses a TLS connection pool, avoid re-creating it.
+///
+/// # Timeouts
+///
+/// If no timeouts are set in the `SdkConfig`, sensible defaults will be enforced here.
 #[must_use]
 pub fn client(
 	config: &SdkConfig,
@@ -60,6 +80,7 @@ pub fn client(
 ) -> aws_sdk_kms::Client {
 	let builder = config
 		.to_builder()
+		.timeout_config(bounded_timeouts(config.timeout_config()))
 		.credentials_provider(SharedCredentialsProvider::new(
 			aws_sdk_kms::config::Credentials::new(
 				credentials.access_key_id,
@@ -69,27 +90,73 @@ pub fn client(
 				"SDK",
 			),
 		))
-		.http_client(VSockHttpClient {
-			address: VsockAddr::new(VSOCK_PROXY_CID, vsock_proxy_port),
-			connectors: RwLock::default(),
-		})
+		.http_client(VSockHttpClient::new(VsockAddr::new(
+			VSOCK_PROXY_CID,
+			vsock_proxy_port,
+		)))
 		.build();
 
 	aws_sdk_kms::Client::new(&builder)
 }
 
-/// The connect and read timeouts the orchestrator resolved for a request.
-type Timeouts = (Option<Duration>, Option<Duration>);
+/// Fills in any timeout the caller left unset
+fn bounded_timeouts(configured: Option<&TimeoutConfig>) -> TimeoutConfig {
+	configured
+		.map(TimeoutConfig::to_builder)
+		.unwrap_or_default()
+		.take_unset_from(
+			TimeoutConfig::builder()
+				.connect_timeout(DEFAULT_CONNECT_TIMEOUT)
+				.read_timeout(DEFAULT_READ_TIMEOUT)
+				.operation_attempt_timeout(DEFAULT_ATTEMPT_TIMEOUT),
+		)
+		.build()
+}
+
+/// The connect and read timeouts in force for a request. Always bounded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct Timeouts {
+	connect: Duration,
+	read: Duration,
+}
+
+/// Idle connections one connector keeps per upstream authority. hyper-util's default is unbounded,
+/// which an enclave cannot afford.
+const MAX_IDLE_CONNECTIONS: usize = 8;
+
+/// Distinct timeout configurations to cache a connector for. A caller that derives a per-request
+/// timeout from a remaining deadline would otherwise grow this map without bound.
+const MAX_CACHED_CONNECTORS: usize = 8;
 
 /// Routes the AWS SDK's HTTP traffic through the host's vsock proxy.
 ///
 /// The orchestrator asks for a connector on every request attempt, so connectors are cached to
-/// keep the underlying connection pool alive across requests. There is one entry per distinct
-/// timeout configuration, which in practice means exactly one.
+/// keep the underlying connection pool alive across requests.
 #[derive(Debug)]
 struct VSockHttpClient {
 	address: VsockAddr,
 	connectors: RwLock<HashMap<Timeouts, SharedHttpConnector>>,
+	cache_full_warned: AtomicBool,
+}
+
+impl VSockHttpClient {
+	fn new(address: VsockAddr) -> Self {
+		Self {
+			address,
+			connectors: RwLock::default(),
+			cache_full_warned: AtomicBool::new(false),
+		}
+	}
+
+	/// Once, not once per request: past the cap this fires at the full request rate.
+	fn warn_cache_full(&self) {
+		if !self.cache_full_warned.swap(true, Ordering::Relaxed) {
+			tracing::warn!(
+				cap = MAX_CACHED_CONNECTORS,
+				"too many distinct timeout configurations; further ones get their own pool"
+			);
+		}
+	}
 }
 
 impl HttpClient for VSockHttpClient {
@@ -98,85 +165,152 @@ impl HttpClient for VSockHttpClient {
 		settings: &HttpConnectorSettings,
 		_: &RuntimeComponents,
 	) -> SharedHttpConnector {
-		let timeouts = (settings.connect_timeout(), settings.read_timeout());
+		// An explicit setting always wins; the default only fills a gap.
+		let timeouts = Timeouts {
+			connect: settings
+				.connect_timeout()
+				.unwrap_or(DEFAULT_CONNECT_TIMEOUT),
+			read: settings.read_timeout().unwrap_or(DEFAULT_READ_TIMEOUT),
+		};
 
-		if let Some(connector) = self
-			.connectors
-			.read()
-			.unwrap_or_else(PoisonError::into_inner)
-			.get(&timeouts)
-		{
-			return connector.clone();
+		let cacheable = {
+			let connectors = self
+				.connectors
+				.read()
+				.unwrap_or_else(PoisonError::into_inner);
+
+			if let Some(connector) = connectors.get(&timeouts) {
+				return connector.clone();
+			}
+
+			connectors.len() < MAX_CACHED_CONNECTORS
+		};
+
+		// Built before taking the write lock: this constructs a rustls `ClientConfig`, and holding
+		// an exclusive lock across that would serialize every concurrent KMS call behind it.
+		let connector = SharedHttpConnector::new(VSockConnector::new(self.address, timeouts));
+
+		if !cacheable {
+			self.warn_cache_full();
+
+			return connector;
 		}
 
 		self.connectors
 			.write()
 			.unwrap_or_else(PoisonError::into_inner)
 			.entry(timeouts)
-			.or_insert_with(|| {
-				SharedHttpConnector::new(VSockConnector::new(self.address, timeouts))
-			})
+			.or_insert(connector)
 			.clone()
+	}
+
+	fn connector_metadata(&self) -> Option<ConnectorMetadata> {
+		Some(ConnectorMetadata::new(
+			"pontifex-vsock",
+			Some(Cow::Borrowed(env!("CARGO_PKG_VERSION"))),
+		))
 	}
 }
 
 #[derive(Debug)]
 struct VSockConnector {
-	client: Client<HttpsConnector<VSockClientBuilder>, SdkBody>,
-	read_timeout: Option<Duration>,
+	client: Client<ConnectTimeout<HttpsConnector<VSockClientBuilder>>, SdkBody>,
+	read_timeout: Duration,
 }
 
+#[cfg(test)]
+static CONNECTORS_BUILT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 impl VSockConnector {
-	fn new(address: VsockAddr, (connect_timeout, read_timeout): Timeouts) -> Self {
+	fn new(address: VsockAddr, timeouts: Timeouts) -> Self {
+		#[cfg(test)]
+		CONNECTORS_BUILT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
 		let mut builder = Client::builder(TokioExecutor::new());
 
-		// Unlike hyper 0.14, hyper-util does not install a timer of its own, and silently drops
-		// pool idle timeouts without one.
 		builder
 			.timer(TokioTimer::new())
-			.pool_timer(TokioTimer::new());
+			.pool_timer(TokioTimer::new())
+			.pool_max_idle_per_host(MAX_IDLE_CONNECTIONS);
 
 		Self {
-			client: builder.build(vsock_proxy_http1(address, connect_timeout)),
-			read_timeout,
+			client: builder.build(vsock_proxy_http1(address, timeouts.connect)),
+			read_timeout: timeouts.read,
 		}
 	}
 }
 
 impl HttpConnector for VSockConnector {
 	fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
-		let request = match request.try_into_http1x() {
+		let mut request = match request.try_into_http1x() {
 			Ok(request) => request,
 			Err(err) => return HttpConnectorFuture::ready(Err(ConnectorError::user(err.into()))),
 		};
 
+		let captured = capture_connection(&mut request);
+
+		if let Some(sink) = request.extensions().get::<CaptureSmithyConnection>() {
+			sink.set_connection_retriever(move || connection_metadata(&captured));
+		}
+
+		let target = request.uri().clone();
 		let response = self.client.request(request);
 		let read_timeout = self.read_timeout;
 
 		HttpConnectorFuture::new(async move {
-			let response = match read_timeout {
-				Some(timeout) => tokio::time::timeout(timeout, response)
-					.await
-					.map_err(|_| read_timed_out(timeout))?,
-				None => response.await,
-			}
-			.map_err(classify_error)?
-			.map(SdkBody::from_body_1_x);
+			let response = await_headers(response, &target, read_timeout)
+				.await?
+				.map(SdkBody::from_body_1_x);
 
 			HttpResponse::try_from(response).map_err(|err| ConnectorError::other(err.into(), None))
 		})
 	}
 }
 
-fn read_timed_out(timeout: Duration) -> ConnectorError {
+/// Bounds the wait for response headers and maps a transport failure onto the SDK's error model.
+async fn await_headers<B>(
+	response: impl Future<Output = Result<hyper::Response<B>, hyper_util::client::legacy::Error>>,
+	target: &hyper::Uri,
+	read_timeout: Duration,
+) -> Result<hyper::Response<B>, ConnectorError> {
+	tokio::time::timeout(read_timeout, response)
+		.await
+		.map_err(|_| read_timed_out(target, read_timeout))?
+		.map_err(|err| {
+			let is_connect = err.is_connect();
+			classify_error(err, is_connect)
+		})
+}
+
+/// Addresses are left unset: a vsock peer has no socket address, and nothing on this path
+/// populates hyper's `HttpInfo`.
+fn connection_metadata(captured: &CaptureConnection) -> Option<ConnectionMetadata> {
+	let proxied = captured.connection_metadata().as_ref()?.is_proxied();
+	let captured = captured.clone();
+
+	Some(
+		ConnectionMetadata::builder()
+			.proxied(proxied)
+			.poison_fn(move || {
+				if let Some(conn) = captured.connection_metadata().as_ref() {
+					conn.poison();
+				}
+			})
+			.build(),
+	)
+}
+
+fn read_timed_out(target: &hyper::Uri, timeout: Duration) -> ConnectorError {
 	ConnectorError::timeout(Box::new(io::Error::new(
 		io::ErrorKind::TimedOut,
-		format!("no response headers within {timeout:?}"),
+		format!("no response headers from {target} within {timeout:?} (connect included)"),
 	)))
 }
 
 /// Classifies a transport failure so the SDK's retry policy can act on it.
-fn classify_error(err: hyper_util::client::legacy::Error) -> ConnectorError {
+///
+/// `is_io` and `is_timeout` are the two classes the SDK retries; everything else is terminal.
+fn classify_error<E: Error + Send + Sync + 'static>(err: E, is_connect: bool) -> ConnectorError {
 	if let Some(hyper_err) = find_source::<hyper::Error>(&err) {
 		if hyper_err.is_timeout() {
 			return ConnectorError::timeout(err.into());
@@ -191,9 +325,31 @@ fn classify_error(err: hyper_util::client::legacy::Error) -> ConnectorError {
 		}
 	}
 
-	if err.is_connect() || find_source::<io::Error>(&err).is_some() {
+	if let Some(rustls::Error::InvalidCertificate(cert_err)) = find_source::<rustls::Error>(&err) {
+		tracing::warn!(
+			error = ?cert_err,
+			"upstream certificate rejected; not retrying"
+		);
+
+		return ConnectorError::other(err.into(), None);
+	}
+
+	if let Some(io_err) = find_source::<io::Error>(&err) {
+		if io_err.kind() == io::ErrorKind::TimedOut {
+			return ConnectorError::timeout(err.into());
+		}
+
 		return ConnectorError::io(err.into());
 	}
+
+	if is_connect {
+		return ConnectorError::io(err.into());
+	}
+
+	tracing::warn!(
+		error = ?err,
+		"unrecognised transport error from hyper; treating it as non-retryable"
+	);
 
 	ConnectorError::other(err.into(), None)
 }
@@ -206,7 +362,13 @@ fn find_source<'a, E: Error + 'static>(err: &'a (dyn Error + 'static)) -> Option
 			return Some(matched);
 		}
 
-		next = err.source();
+		// `io::Error::source()` returns the source of the error it wraps, skipping the wrapped
+		// error itself, so step into it explicitly or everything behind one is invisible.
+		next = err
+			.downcast_ref::<io::Error>()
+			.and_then(io::Error::get_ref)
+			.map(|inner| inner as &(dyn Error + 'static))
+			.or_else(|| err.source());
 	}
 
 	None
@@ -231,6 +393,18 @@ mod tests {
 		}
 	}
 
+	/// An error with nothing the classifier recognises in its chain.
+	#[derive(Debug)]
+	struct Opaque;
+
+	impl std::fmt::Display for Opaque {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			f.write_str("opaque")
+		}
+	}
+
+	impl Error for Opaque {}
+
 	/// Transient transport failures reach us wrapped, and are only retried if they are recognised.
 	#[test]
 	fn find_source_walks_the_error_chain() {
@@ -241,5 +415,194 @@ mod tests {
 			Some(io::ErrorKind::ConnectionReset)
 		);
 		assert!(find_source::<std::fmt::Error>(&err).is_none());
+	}
+
+	#[test]
+	fn an_unset_timeout_config_is_fully_bounded() {
+		let bounded = bounded_timeouts(None);
+
+		assert_eq!(bounded.connect_timeout(), Some(DEFAULT_CONNECT_TIMEOUT));
+		assert_eq!(bounded.read_timeout(), Some(DEFAULT_READ_TIMEOUT));
+		assert_eq!(
+			bounded.operation_attempt_timeout(),
+			Some(DEFAULT_ATTEMPT_TIMEOUT)
+		);
+	}
+
+	/// A caller's own timeout has to win, or configuring one would be pointless.
+	#[test]
+	fn a_configured_timeout_is_not_overridden() {
+		let configured = TimeoutConfig::builder()
+			.read_timeout(Duration::from_secs(1))
+			.build();
+
+		let bounded = bounded_timeouts(Some(&configured));
+
+		assert_eq!(bounded.read_timeout(), Some(Duration::from_secs(1)));
+		assert_eq!(bounded.connect_timeout(), Some(DEFAULT_CONNECT_TIMEOUT));
+	}
+
+	/// `disabled()` is an explicit choice, distinct from leaving a timeout unset.
+	#[test]
+	fn explicitly_disabled_timeouts_stay_disabled() {
+		let bounded = bounded_timeouts(Some(&TimeoutConfig::disabled()));
+
+		assert_eq!(bounded.read_timeout(), None);
+		assert_eq!(bounded.connect_timeout(), None);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn headers_that_never_arrive_time_out() {
+		let never = std::future::pending::<
+			Result<hyper::Response<()>, hyper_util::client::legacy::Error>,
+		>();
+
+		let err = await_headers(
+			never,
+			&hyper::Uri::from_static("https://kms.eu-west-1.amazonaws.com"),
+			Duration::from_secs(5),
+		)
+		.await
+		.expect_err("headers that never arrive must time out");
+
+		assert!(err.is_timeout(), "got {err:?}");
+	}
+
+	#[test]
+	fn a_read_timeout_names_its_target() {
+		let err = read_timed_out(
+			&hyper::Uri::from_static("https://kms.eu-west-1.amazonaws.com/"),
+			Duration::from_secs(5),
+		);
+
+		assert!(format!("{err:?}").contains("kms.eu-west-1"), "got {err:?}");
+	}
+
+	#[test]
+	fn find_source_sees_through_an_io_error() {
+		let err = io::Error::other(rustls::Error::InvalidCertificate(
+			rustls::CertificateError::UnknownIssuer,
+		));
+
+		assert!(find_source::<rustls::Error>(&err).is_some());
+	}
+
+	#[test]
+	fn a_rejected_certificate_is_terminal() {
+		let err = classify_error(
+			io::Error::other(rustls::Error::InvalidCertificate(
+				rustls::CertificateError::UnknownIssuer,
+			)),
+			true,
+		);
+
+		assert!(
+			err.is_other(),
+			"a bad certificate must not be retried, got {err:?}"
+		);
+	}
+
+	#[test]
+	fn a_wrapped_connection_reset_is_retryable() {
+		let err = classify_error(
+			Wrapper(io::Error::from(io::ErrorKind::ConnectionReset)),
+			false,
+		);
+
+		assert!(
+			err.is_io(),
+			"a reset connection must be retried, got {err:?}"
+		);
+	}
+
+	#[test]
+	fn a_timed_out_connect_is_classified_as_a_timeout() {
+		let err = classify_error(Wrapper(io::Error::from(io::ErrorKind::TimedOut)), true);
+
+		assert!(err.is_timeout(), "got {err:?}");
+	}
+
+	#[test]
+	fn a_connect_failure_with_no_io_source_is_still_retryable() {
+		let err = classify_error(Opaque, true);
+
+		assert!(err.is_io(), "got {err:?}");
+	}
+
+	#[test]
+	fn an_unrecognized_failure_is_terminal() {
+		let err = classify_error(Opaque, false);
+
+		assert!(err.is_other(), "got {err:?}");
+	}
+
+	/// `CONNECTORS_BUILT` is process-wide, so every test that can build a connector has to go
+	/// through this or the counting tests race each other.
+	static COUNTER_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+	/// Runs `body` with exclusive access to `CONNECTORS_BUILT`, returning how many connectors it
+	/// built.
+	fn counting_connectors(body: impl FnOnce()) -> usize {
+		use std::sync::atomic::Ordering;
+
+		let _guard = COUNTER_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+		let before = CONNECTORS_BUILT.load(Ordering::Relaxed);
+		body();
+
+		CONNECTORS_BUILT.load(Ordering::Relaxed) - before
+	}
+
+	/// Re-resolving a connector has to hand back the existing one; building a fresh one would give
+	/// every request its own connection pool and reconnect each time.
+	#[test]
+	fn a_repeated_timeout_configuration_reuses_its_connector() {
+		use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+
+		let client = VSockHttpClient::new(VsockAddr::new(VSOCK_PROXY_CID, 8000));
+		let components = RuntimeComponentsBuilder::for_tests().build().unwrap();
+		let settings = HttpConnectorSettings::builder()
+			.connect_timeout(Duration::from_secs(3))
+			.build();
+		let other = HttpConnectorSettings::builder()
+			.connect_timeout(Duration::from_secs(7))
+			.build();
+
+		let built = counting_connectors(|| {
+			client.http_connector(&settings, &components);
+			client.http_connector(&settings, &components);
+			client.http_connector(&other, &components);
+		});
+
+		assert_eq!(
+			built, 2,
+			"two distinct timeout configurations, so exactly two connectors"
+		);
+	}
+
+	#[test]
+	fn the_connector_cache_is_bounded() {
+		use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
+
+		let client = VSockHttpClient::new(VsockAddr::new(VSOCK_PROXY_CID, 8000));
+		let components = RuntimeComponentsBuilder::for_tests().build().unwrap();
+
+		counting_connectors(|| {
+			for millis in 0..(MAX_CACHED_CONNECTORS as u64 + 5) {
+				let settings = HttpConnectorSettings::builder()
+					.read_timeout(Duration::from_millis(millis + 1))
+					.build();
+
+				client.http_connector(&settings, &components);
+			}
+		});
+
+		assert_eq!(
+			client
+				.connectors
+				.read()
+				.unwrap_or_else(PoisonError::into_inner)
+				.len(),
+			MAX_CACHED_CONNECTORS
+		);
 	}
 }

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -1,9 +1,30 @@
+use std::{
+	collections::HashMap,
+	error::Error,
+	io,
+	sync::{PoisonError, RwLock},
+	time::Duration,
+};
+
 use aws_sdk_kms::config::SharedCredentialsProvider;
-use aws_smithy_http_client::hyper_014::HyperClientBuilder;
+use aws_smithy_runtime_api::client::{
+	http::{
+		HttpClient, HttpConnector, HttpConnectorFuture, HttpConnectorSettings, SharedHttpConnector,
+	},
+	orchestrator::{HttpRequest, HttpResponse},
+	result::ConnectorError,
+	runtime_components::RuntimeComponents,
+};
+use aws_smithy_types::body::SdkBody;
 use aws_types::SdkConfig;
+use hyper_rustls::HttpsConnector;
+use hyper_util::{
+	client::legacy::Client,
+	rt::{TokioExecutor, TokioTimer},
+};
 use tokio_vsock::VsockAddr;
 
-use crate::utils::http::vsock_proxy;
+use crate::utils::http::{VSockClientBuilder, vsock_proxy_http1};
 
 /// The CID of the vsock proxy.
 pub const VSOCK_PROXY_CID: u32 = 3;
@@ -48,11 +69,177 @@ pub fn client(
 				"SDK",
 			),
 		))
-		.http_client(HyperClientBuilder::new().build(vsock_proxy(VsockAddr::new(
-			VSOCK_PROXY_CID,
-			vsock_proxy_port,
-		))))
+		.http_client(VSockHttpClient {
+			address: VsockAddr::new(VSOCK_PROXY_CID, vsock_proxy_port),
+			connectors: RwLock::default(),
+		})
 		.build();
 
 	aws_sdk_kms::Client::new(&builder)
+}
+
+/// The connect and read timeouts the orchestrator resolved for a request.
+type Timeouts = (Option<Duration>, Option<Duration>);
+
+/// Routes the AWS SDK's HTTP traffic through the host's vsock proxy.
+///
+/// The orchestrator asks for a connector on every request attempt, so connectors are cached to
+/// keep the underlying connection pool alive across requests. There is one entry per distinct
+/// timeout configuration, which in practice means exactly one.
+#[derive(Debug)]
+struct VSockHttpClient {
+	address: VsockAddr,
+	connectors: RwLock<HashMap<Timeouts, SharedHttpConnector>>,
+}
+
+impl HttpClient for VSockHttpClient {
+	fn http_connector(
+		&self,
+		settings: &HttpConnectorSettings,
+		_: &RuntimeComponents,
+	) -> SharedHttpConnector {
+		let timeouts = (settings.connect_timeout(), settings.read_timeout());
+
+		if let Some(connector) = self
+			.connectors
+			.read()
+			.unwrap_or_else(PoisonError::into_inner)
+			.get(&timeouts)
+		{
+			return connector.clone();
+		}
+
+		self.connectors
+			.write()
+			.unwrap_or_else(PoisonError::into_inner)
+			.entry(timeouts)
+			.or_insert_with(|| {
+				SharedHttpConnector::new(VSockConnector::new(self.address, timeouts))
+			})
+			.clone()
+	}
+}
+
+#[derive(Debug)]
+struct VSockConnector {
+	client: Client<HttpsConnector<VSockClientBuilder>, SdkBody>,
+	read_timeout: Option<Duration>,
+}
+
+impl VSockConnector {
+	fn new(address: VsockAddr, (connect_timeout, read_timeout): Timeouts) -> Self {
+		let mut builder = Client::builder(TokioExecutor::new());
+
+		// Unlike hyper 0.14, hyper-util does not install a timer of its own, and silently drops
+		// pool idle timeouts without one.
+		builder
+			.timer(TokioTimer::new())
+			.pool_timer(TokioTimer::new());
+
+		Self {
+			client: builder.build(vsock_proxy_http1(address, connect_timeout)),
+			read_timeout,
+		}
+	}
+}
+
+impl HttpConnector for VSockConnector {
+	fn call(&self, request: HttpRequest) -> HttpConnectorFuture {
+		let request = match request.try_into_http1x() {
+			Ok(request) => request,
+			Err(err) => return HttpConnectorFuture::ready(Err(ConnectorError::user(err.into()))),
+		};
+
+		let response = self.client.request(request);
+		let read_timeout = self.read_timeout;
+
+		HttpConnectorFuture::new(async move {
+			let response = match read_timeout {
+				Some(timeout) => tokio::time::timeout(timeout, response)
+					.await
+					.map_err(|_| read_timed_out(timeout))?,
+				None => response.await,
+			}
+			.map_err(classify_error)?
+			.map(SdkBody::from_body_1_x);
+
+			HttpResponse::try_from(response).map_err(|err| ConnectorError::other(err.into(), None))
+		})
+	}
+}
+
+fn read_timed_out(timeout: Duration) -> ConnectorError {
+	ConnectorError::timeout(Box::new(io::Error::new(
+		io::ErrorKind::TimedOut,
+		format!("no response headers within {timeout:?}"),
+	)))
+}
+
+/// Classifies a transport failure so the SDK's retry policy can act on it.
+fn classify_error(err: hyper_util::client::legacy::Error) -> ConnectorError {
+	if let Some(hyper_err) = find_source::<hyper::Error>(&err) {
+		if hyper_err.is_timeout() {
+			return ConnectorError::timeout(err.into());
+		}
+
+		if hyper_err.is_user() {
+			return ConnectorError::user(err.into());
+		}
+
+		if hyper_err.is_closed() || hyper_err.is_canceled() || hyper_err.is_incomplete_message() {
+			return ConnectorError::io(err.into());
+		}
+	}
+
+	if err.is_connect() || find_source::<io::Error>(&err).is_some() {
+		return ConnectorError::io(err.into());
+	}
+
+	ConnectorError::other(err.into(), None)
+}
+
+fn find_source<'a, E: Error + 'static>(err: &'a (dyn Error + 'static)) -> Option<&'a E> {
+	let mut next = Some(err);
+
+	while let Some(err) = next {
+		if let Some(matched) = err.downcast_ref::<E>() {
+			return Some(matched);
+		}
+
+		next = err.source();
+	}
+
+	None
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[derive(Debug)]
+	struct Wrapper(io::Error);
+
+	impl std::fmt::Display for Wrapper {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			f.write_str("wrapper")
+		}
+	}
+
+	impl Error for Wrapper {
+		fn source(&self) -> Option<&(dyn Error + 'static)> {
+			Some(&self.0)
+		}
+	}
+
+	/// Transient transport failures reach us wrapped, and are only retried if they are recognised.
+	#[test]
+	fn find_source_walks_the_error_chain() {
+		let err = Wrapper(io::Error::from(io::ErrorKind::ConnectionReset));
+
+		assert_eq!(
+			find_source::<io::Error>(&err).map(io::Error::kind),
+			Some(io::ErrorKind::ConnectionReset)
+		);
+		assert!(find_source::<std::fmt::Error>(&err).is_none());
+	}
 }

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -23,13 +23,13 @@ use tower_service::Service;
 #[cfg(feature = "kms")]
 pub fn vsock_proxy_http1(
 	address: VsockAddr,
-	connect_timeout: Duration,
+	connect_timeout: Option<Duration>,
 ) -> ConnectTimeout<HttpsConnector<VSockClientBuilder>> {
 	ConnectTimeout {
 		inner: tls_builder()
 			.enable_http1()
 			.wrap_connector(VSockClientBuilder { address }),
-		timeout: Some(connect_timeout),
+		timeout: connect_timeout,
 	}
 }
 
@@ -231,7 +231,7 @@ mod tests {
 	#[cfg(feature = "kms")]
 	#[test]
 	fn the_http1_connector_keeps_the_bound_it_was_given() {
-		let connector = vsock_proxy_http1(VsockAddr::new(3, 8000), Duration::from_secs(7));
+		let connector = vsock_proxy_http1(VsockAddr::new(3, 8000), Some(Duration::from_secs(7)));
 
 		assert_eq!(connector.timeout(), Some(Duration::from_secs(7)));
 	}
@@ -262,7 +262,7 @@ mod tests {
 	#[cfg(feature = "kms")]
 	#[tokio::test]
 	async fn a_plaintext_uri_is_refused_rather_than_forwarded() {
-		let result = vsock_proxy_http1(VsockAddr::new(3, 8000), Duration::from_secs(1))
+		let result = vsock_proxy_http1(VsockAddr::new(3, 8000), Some(Duration::from_secs(1)))
 			.call(Uri::from_static("http://kms.eu-west-1.amazonaws.com"))
 			.await;
 

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -23,25 +23,28 @@ use tower_service::Service;
 #[cfg(feature = "kms")]
 pub fn vsock_proxy_http1(
 	address: VsockAddr,
-	connect_timeout: Option<Duration>,
-) -> HttpsConnector<VSockClientBuilder> {
-	tls_builder()
-		.enable_http1()
-		.wrap_connector(VSockClientBuilder {
-			address,
-			connect_timeout,
-		})
+	connect_timeout: Duration,
+) -> ConnectTimeout<HttpsConnector<VSockClientBuilder>> {
+	ConnectTimeout {
+		inner: tls_builder()
+			.enable_http1()
+			.wrap_connector(VSockClientBuilder { address }),
+		timeout: Some(connect_timeout),
+	}
 }
 
 /// An HTTPS-over-vsock connector that advertises only `h2` over ALPN.
 #[cfg(feature = "http")]
-pub fn vsock_proxy_http2(address: VsockAddr) -> HttpsConnector<VSockClientBuilder> {
-	tls_builder()
-		.enable_http2()
-		.wrap_connector(VSockClientBuilder {
-			address,
-			connect_timeout: None,
-		})
+pub fn vsock_proxy_http2(
+	address: VsockAddr,
+	connect_timeout: Option<Duration>,
+) -> ConnectTimeout<HttpsConnector<VSockClientBuilder>> {
+	ConnectTimeout {
+		inner: tls_builder()
+			.enable_http2()
+			.wrap_connector(VSockClientBuilder { address }),
+		timeout: connect_timeout,
+	}
 }
 
 fn tls_builder() -> HttpsConnectorBuilder<hyper_rustls::builderstates::WantsProtocols1> {
@@ -55,9 +58,11 @@ fn tls_builder() -> HttpsConnectorBuilder<hyper_rustls::builderstates::WantsProt
 	.with_webpki_roots()
 	.with_no_client_auth();
 
+	// `https_only` rather than `https_or_http`: the host-side proxy is untrusted, so an `http://`
+	// URI must fail rather than hand it the request in the clear.
 	HttpsConnectorBuilder::new()
 		.with_tls_config(config)
-		.https_or_http()
+		.https_only()
 }
 
 /// A connector builder for creating vsock-based HTTP(S) connections.
@@ -68,7 +73,6 @@ fn tls_builder() -> HttpsConnectorBuilder<hyper_rustls::builderstates::WantsProt
 #[derive(Debug, Clone, Copy)]
 pub struct VSockClientBuilder {
 	address: VsockAddr,
-	connect_timeout: Option<Duration>,
 }
 
 pub struct VSockClient {
@@ -95,22 +99,7 @@ impl Service<Uri> for VSockClientBuilder {
 	}
 
 	fn call(&mut self, _: Uri) -> Self::Future {
-		let address = self.address;
-
-		let Some(timeout) = self.connect_timeout else {
-			return Box::pin(VSockClient::connect(address));
-		};
-
-		Box::pin(async move {
-			tokio::time::timeout(timeout, VSockClient::connect(address))
-				.await
-				.map_err(|_| {
-					io::Error::new(
-						io::ErrorKind::TimedOut,
-						format!("vsock connect to {address:?} timed out after {timeout:?}"),
-					)
-				})?
-		})
+		Box::pin(VSockClient::connect(self.address))
 	}
 }
 
@@ -154,5 +143,148 @@ impl Drop for VSockClient {
 impl Connection for VSockClient {
 	fn connected(&self) -> Connected {
 		Connected::new()
+	}
+}
+
+/// Bounds the time a connector may spend establishing a connection.\
+#[derive(Debug, Clone)]
+pub struct ConnectTimeout<C> {
+	inner: C,
+	timeout: Option<Duration>,
+}
+
+#[cfg(any(feature = "http", test))]
+impl<C> ConnectTimeout<C> {
+	/// The bound this connector applies, or `None` if connects are unbounded.
+	#[must_use]
+	pub const fn timeout(&self) -> Option<Duration> {
+		self.timeout
+	}
+}
+
+impl<C> Service<Uri> for ConnectTimeout<C>
+where
+	C: Service<Uri>,
+	C::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+	C::Response: Send + 'static,
+	C::Future: Send + 'static,
+{
+	type Response = C::Response;
+	type Error = Box<dyn std::error::Error + Send + Sync>;
+	type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+	fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+		self.inner.poll_ready(cx).map_err(Into::into)
+	}
+
+	fn call(&mut self, uri: Uri) -> Self::Future {
+		let target = uri.clone();
+		let connect = self.inner.call(uri);
+
+		let Some(timeout) = self.timeout else {
+			return Box::pin(async move { connect.await.map_err(Into::into) });
+		};
+
+		Box::pin(async move {
+			tokio::time::timeout(timeout, connect)
+				.await
+				.map_err(|_| -> Self::Error {
+					io::Error::new(
+						io::ErrorKind::TimedOut,
+						format!("vsock dial and TLS handshake to {target} exceeded {timeout:?}"),
+					)
+					.into()
+				})?
+				.map_err(Into::into)
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// A connector whose future never resolves, standing in for a proxy that accepts the vsock
+	/// connection and then stalls partway through the TLS handshake.
+	#[derive(Clone)]
+	struct Stalls;
+
+	impl Service<Uri> for Stalls {
+		type Response = ();
+		type Error = io::Error;
+		type Future = Pin<Box<dyn Future<Output = Result<(), io::Error>> + Send>>;
+
+		fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+			Poll::Ready(Ok(()))
+		}
+
+		fn call(&mut self, _: Uri) -> Self::Future {
+			Box::pin(std::future::pending())
+		}
+	}
+
+	fn target() -> Uri {
+		Uri::from_static("https://kms.eu-west-1.amazonaws.com")
+	}
+
+	/// The KMS path passes its own bound in; dropping it on the floor would silently unbound it.
+	#[cfg(feature = "kms")]
+	#[test]
+	fn the_http1_connector_keeps_the_bound_it_was_given() {
+		let connector = vsock_proxy_http1(VsockAddr::new(3, 8000), Duration::from_secs(7));
+
+		assert_eq!(connector.timeout(), Some(Duration::from_secs(7)));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn a_stalled_connect_is_bounded() {
+		let mut connector = ConnectTimeout {
+			inner: Stalls,
+			timeout: Some(Duration::from_secs(5)),
+		};
+
+		let err = connector
+			.call(target())
+			.await
+			.expect_err("a connect that never resolves must fail");
+		let err = err.downcast_ref::<io::Error>().expect("an io error");
+
+		assert_eq!(err.kind(), io::ErrorKind::TimedOut);
+		// The message has to name the target, or a dead proxy and a dead upstream look identical.
+		assert!(
+			err.to_string().contains("kms.eu-west-1.amazonaws.com"),
+			"got {err}"
+		);
+	}
+
+	/// hyper-rustls rejects a non-HTTPS URI before it reaches the inner connector, so this never
+	/// touches vsock.
+	#[cfg(feature = "kms")]
+	#[tokio::test]
+	async fn a_plaintext_uri_is_refused_rather_than_forwarded() {
+		let result = vsock_proxy_http1(VsockAddr::new(3, 8000), Duration::from_secs(1))
+			.call(Uri::from_static("http://kms.eu-west-1.amazonaws.com"))
+			.await;
+
+		let Err(err) = result else {
+			panic!("an http:// URI must not be forwarded to the host proxy in the clear")
+		};
+
+		assert!(err.to_string().contains("scheme"), "got {err}");
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn a_stalled_connect_without_a_timeout_is_left_alone() {
+		let mut connector = ConnectTimeout {
+			inner: Stalls,
+			timeout: None,
+		};
+
+		assert!(
+			tokio::time::timeout(Duration::from_secs(30), connector.call(target()))
+				.await
+				.is_err(),
+			"no timeout was configured, so nothing should bound the connect"
+		);
 	}
 }

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -1,34 +1,63 @@
-use hyper::{
-	Uri,
-	client::connect::{Connected, Connection},
-	service::Service,
-};
-use hyper_rustls::{ConfigBuilderExt, HttpsConnector};
 use std::{
 	io,
 	net::Shutdown,
 	pin::Pin,
+	sync::Arc,
 	task::{Context, Poll},
+	time::Duration,
 };
-use tokio::io::{AsyncRead, AsyncWrite};
+
+use hyper::{
+	Uri,
+	rt::{Read, ReadBufCursor, Write},
+};
+use hyper_rustls::{ConfigBuilderExt, HttpsConnector, HttpsConnectorBuilder};
+use hyper_util::{
+	client::legacy::connect::{Connected, Connection},
+	rt::TokioIo,
+};
 use tokio_vsock::{VsockAddr, VsockStream};
+use tower_service::Service;
 
-pub fn vsock_proxy(address: VsockAddr) -> HttpsConnector<VSockClientBuilder> {
-	let cc = rustls::ClientConfig::builder()
-		.with_webpki_roots()
-		.with_no_client_auth();
-
-	HttpsConnector::from((VSockClientBuilder { address }, cc))
+/// An HTTPS-over-vsock connector for HTTP/1.1.
+#[cfg(feature = "kms")]
+pub fn vsock_proxy_http1(
+	address: VsockAddr,
+	connect_timeout: Option<Duration>,
+) -> HttpsConnector<VSockClientBuilder> {
+	tls_builder()
+		.enable_http1()
+		.wrap_connector(VSockClientBuilder {
+			address,
+			connect_timeout,
+		})
 }
 
-pub fn vsock_proxy_http2_only(address: VsockAddr) -> HttpsConnector<VSockClientBuilder> {
-	let mut cc = rustls::ClientConfig::builder()
-		.with_webpki_roots()
-		.with_no_client_auth();
+/// An HTTPS-over-vsock connector that advertises only `h2` over ALPN.
+#[cfg(feature = "http")]
+pub fn vsock_proxy_http2(address: VsockAddr) -> HttpsConnector<VSockClientBuilder> {
+	tls_builder()
+		.enable_http2()
+		.wrap_connector(VSockClientBuilder {
+			address,
+			connect_timeout: None,
+		})
+}
 
-	cc.alpn_protocols = vec![b"h2".to_vec()];
+fn tls_builder() -> HttpsConnectorBuilder<hyper_rustls::builderstates::WantsProtocols1> {
+	// Naming the provider avoids rustls' "could not determine the process-level `CryptoProvider`"
+	// panic, which fires whenever something else in the tree also enables `aws_lc_rs`.
+	let config = rustls::ClientConfig::builder_with_provider(Arc::new(
+		rustls::crypto::ring::default_provider(),
+	))
+	.with_safe_default_protocol_versions()
+	.expect("ring supports the default protocol versions")
+	.with_webpki_roots()
+	.with_no_client_auth();
 
-	HttpsConnector::from((VSockClientBuilder { address }, cc))
+	HttpsConnectorBuilder::new()
+		.with_tls_config(config)
+		.https_or_http()
 }
 
 /// A connector builder for creating vsock-based HTTP(S) connections.
@@ -39,10 +68,11 @@ pub fn vsock_proxy_http2_only(address: VsockAddr) -> HttpsConnector<VSockClientB
 #[derive(Debug, Clone, Copy)]
 pub struct VSockClientBuilder {
 	address: VsockAddr,
+	connect_timeout: Option<Duration>,
 }
 
 pub struct VSockClient {
-	stream: Option<VsockStream>,
+	io: TokioIo<VsockStream>,
 }
 
 impl VSockClient {
@@ -50,18 +80,8 @@ impl VSockClient {
 		let stream = VsockStream::connect(address).await?;
 
 		Ok(Self {
-			stream: Some(stream),
+			io: TokioIo::new(stream),
 		})
-	}
-
-	fn with_pinned_stream<T>(&mut self, closure: impl FnOnce(Pin<&mut VsockStream>) -> T) -> T {
-		let mut stream = self.stream.take().expect("stream is None");
-		let pinned_stream = Pin::new(&mut stream);
-
-		let result = closure(pinned_stream);
-
-		self.stream = Some(stream);
-		result
 	}
 }
 
@@ -75,46 +95,59 @@ impl Service<Uri> for VSockClientBuilder {
 	}
 
 	fn call(&mut self, _: Uri) -> Self::Future {
-		Box::pin(VSockClient::connect(self.address))
+		let address = self.address;
+
+		let Some(timeout) = self.connect_timeout else {
+			return Box::pin(VSockClient::connect(address));
+		};
+
+		Box::pin(async move {
+			tokio::time::timeout(timeout, VSockClient::connect(address))
+				.await
+				.map_err(|_| {
+					io::Error::new(
+						io::ErrorKind::TimedOut,
+						format!("vsock connect to {address:?} timed out after {timeout:?}"),
+					)
+				})?
+		})
 	}
 }
 
-impl AsyncRead for VSockClient {
+impl Read for VSockClient {
 	fn poll_read(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,
-		buf: &mut tokio::io::ReadBuf<'_>,
+		buf: ReadBufCursor<'_>,
 	) -> Poll<io::Result<()>> {
-		self.with_pinned_stream(|stream| stream.poll_read(cx, buf))
+		Pin::new(&mut self.io).poll_read(cx, buf)
 	}
 }
 
-impl AsyncWrite for VSockClient {
+impl Write for VSockClient {
 	fn poll_write(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,
 		buf: &[u8],
 	) -> Poll<Result<usize, io::Error>> {
-		self.with_pinned_stream(|stream| stream.poll_write(cx, buf))
+		Pin::new(&mut self.io).poll_write(cx, buf)
 	}
 
 	fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-		self.with_pinned_stream(|stream| stream.poll_flush(cx))
+		Pin::new(&mut self.io).poll_flush(cx)
 	}
 
 	fn poll_shutdown(
 		mut self: Pin<&mut Self>,
 		cx: &mut Context<'_>,
 	) -> Poll<Result<(), io::Error>> {
-		self.with_pinned_stream(|stream| stream.poll_shutdown(cx))
+		Pin::new(&mut self.io).poll_shutdown(cx)
 	}
 }
 
 impl Drop for VSockClient {
 	fn drop(&mut self) {
-		self.stream
-			.as_ref()
-			.map(|stream| stream.shutdown(Shutdown::Both));
+		_ = self.io.inner().shutdown(Shutdown::Both);
 	}
 }
 


### PR DESCRIPTION
### Changes
- Bumps to `hyper 1.x` (which addresses several RUSTSEC advisories).
- Implements a custom `HttpClient` for the KMS module. This was necessary with the hyper bump, removing `aws-smithy-http-client` because we need as custom connector to tunnel the http request through vsock.
- Adds timeouts to all http requests (including KMS) all throughout to avoid connections hanging.


### ⚠️ Breaking Changes
- The `HttpClient` interface and `VSockClientBuilder` have changed.
- Bumps to `hyper 1.x` (major version bump)
- Rejects `http://` urls.
- The HTTP Client now enforces a 10s timeout by default and KMS a 60s timeout.

This PR was AI-driven.