### PR TITLE
chore: add kilianglas to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @m1guelpf @paolodamico @aurel-fr @Takaros999 @andy-t-wang @kilianglas
+* @m1guelpf @paolodamico @aurel-fr @Takaros999 @kilianglas

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @m1guelpf @paolodamico @aurel-fr @Takaros999 @andy-t-wang
+* @m1guelpf @paolodamico @aurel-fr @Takaros999 @andy-t-wang @kilianglas


### PR DESCRIPTION
Adds `@kilianglas` to the catch-all owner rule, so I get review requests on this repo.

Also adds the missing trailing newline on the file.