### PR TITLE
feat: sealed channel for communication

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @m1guelpf @paolodamico @aurel-fr @Takaros999 @kilianglas @0xOsiris

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     interval: "monthly"
   assignees:
   - "Takaros999"
+  - "kilianglas"
+  cooldown:
+    default-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,16 @@ jobs:
             - name: Build
               run: cargo build
 
+            - name: Install cargo-hack
+              uses: taiki-e/install-action@e67fa11c4b9316fa714ddf0abed07a0c3143b95b #v2.87.4 https://github.com/taiki-e/install-action/releases/tag/v2.87.4
+              with:
+                  tool: cargo-hack@0.6.45
+
+            - name: Check each feature on its own
+              run: |
+                  cargo hack check --each-feature --no-dev-deps
+                  cargo hack check --each-feature --all-targets
+
     test:
         name: Tests
         runs-on: ubuntu-latest

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @m1guelpf @paolodamico @aurel-fr @Takaros999 @kilianglas

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,7 @@ aws-smithy-http-client = { version = "1.0.2", features = ["hyper-014"], optional
 aws-nitro-enclaves-nsm-api = { version = "0.4", optional = true, default-features = false }
 const-fnv1a-hash = "1.1.0"
 
-# `channel` feature. HKDF for the response derivation in RFC 9458 §4.4, pinned to the 0.13 line
-# because that is what `hpke` already resolves for its own HKDF-SHA256.
+# `channel` feature. HKDF 0.13 is what `hpke` already resolves for its own HKDF-SHA256.
 hkdf = { version = "0.13", optional = true }
 # rust-hpke: the only Rust HPKE implementation with an independent security review. Default
 # features are off so `mlkem` does not drag ml-kem, x-wing and sha3 into an enclave image;
@@ -78,10 +77,8 @@ hkdf = { version = "0.13", optional = true }
 hpke = { version = "0.14", default-features = false, features = ["alloc", "x25519", "aes"], optional = true }
 aes-gcm = { version = "0.11", default-features = false, features = ["aes", "alloc"], optional = true }
 zeroize = { version = "1", default-features = false, features = ["alloc"], optional = true }
-# Renamed rather than shared with the `sha2` above: the channel's SHA-256 must be the generation
-# `hpke` and `hkdf` already resolve for HKDF-SHA256 (0.11), while `nsm-types` is still on 0.10.
-# Enabling both features therefore links two SHA-256 implementations; unify by moving
-# `nsm-types` to 0.11, which is a separate change to `nsm.rs`.
+# Renamed, not shared with the `sha2` above: the channel needs the 0.11 generation `hpke` and
+# `hkdf` resolve, while `nsm-types` is on 0.10. Both features together link two SHA-256s.
 channel-sha2 = { package = "sha2", version = "0.11", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,13 @@ nsm-types = [
     "dep:aws-nitro-enclaves-nsm-api",
 ]
 http = ["dep:hyper", "dep:rustls", "dep:hyper-rustls"]
+channel = [
+    "dep:hkdf",
+    "dep:hpke",
+    "dep:aes-gcm",
+    "dep:zeroize",
+    "dep:channel-sha2",
+]
 kms = [
     "dep:hyper",
     "dep:rustls",
@@ -61,5 +68,23 @@ aws-smithy-http-client = { version = "1.0.2", features = ["hyper-014"], optional
 aws-nitro-enclaves-nsm-api = { version = "0.4", optional = true, default-features = false }
 const-fnv1a-hash = "1.1.0"
 
+# `channel` feature. HKDF for the response derivation in RFC 9458 §4.4, pinned to the 0.13 line
+# because that is what `hpke` already resolves for its own HKDF-SHA256.
+hkdf = { version = "0.13", optional = true }
+# rust-hpke: the only Rust HPKE implementation with an independent security review. Default
+# features are off so `mlkem` does not drag ml-kem, x-wing and sha3 into an enclave image;
+# `x25519` transitively enables `hkdfsha2`, which the DHKEM(X25519, HKDF-SHA256) suite needs.
+# Revisit `mlkem`/`x-wing` if the KEM ever needs to be post-quantum hybrid.
+hpke = { version = "0.14", default-features = false, features = ["alloc", "x25519", "aes"], optional = true }
+aes-gcm = { version = "0.11", default-features = false, features = ["aes", "alloc"], optional = true }
+zeroize = { version = "1", default-features = false, features = ["alloc"], optional = true }
+# Renamed rather than shared with the `sha2` above: the channel's SHA-256 must be the generation
+# `hpke` and `hkdf` already resolve for HKDF-SHA256 (0.11), while `nsm-types` is still on 0.10.
+# Enabling both features therefore links two SHA-256 implementations; unify by moving
+# `nsm-types` to 0.11, which is a separate change to `nsm.rs`.
+channel-sha2 = { package = "sha2", version = "0.11", default-features = false, optional = true }
+
 [dev-dependencies]
 tokio-test = "0.4"
+hex-literal = "1.1"
+getrandom = { version = "0.4", features = ["sys_rng"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,7 @@ nsm-types = [
 ]
 http = ["_vsock-https"]
 channel = [
-    "dep:hkdf",
-    "dep:hpke",
-    "dep:aes-gcm",
-    "dep:zeroize",
-    "dep:channel-sha2",
+    "dep:quantum-box",
 ]
 kms = [
     "_vsock-https",
@@ -55,6 +51,7 @@ _vsock-https = [
 all-features = true
 
 [dependencies]
+const-fnv1a-hash = "1.1.0"
 serde = "1"
 tracing = "0.1"
 rmp-serde = "1"
@@ -94,27 +91,11 @@ rustls = { version = "0.23", optional = true, default-features = false, features
     "std",
     "tls12",
 ] }
-const-fnv1a-hash = "1.1.0"
-
-# `channel` feature. HKDF 0.13 is what `hpke` already resolves for its own HKDF-SHA256.
-hkdf = { version = "0.13", optional = true }
-# rust-hpke: the only Rust HPKE implementation with an independent security review. Default
-# features are off so `mlkem` does not drag ml-kem, x-wing and sha3 into an enclave image;
-# `x25519` transitively enables `hkdfsha2`, which the DHKEM(X25519, HKDF-SHA256) suite needs.
-# Revisit `mlkem`/`x-wing` if the KEM ever needs to be post-quantum hybrid.
-hpke = { version = "0.14", default-features = false, features = ["alloc", "x25519", "aes"], optional = true }
-aes-gcm = { version = "0.11", default-features = false, features = ["aes", "alloc"], optional = true }
-zeroize = { version = "1", default-features = false, features = ["alloc"], optional = true }
-# Renamed, not shared with the `sha2` above: the channel needs the 0.11 generation `hpke` and
-# `hkdf` resolve, while `nsm-types` is on 0.10. Both features together link two SHA-256s.
-channel-sha2 = { package = "sha2", version = "0.11", default-features = false, optional = true }
+quantum-box = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"
-<<<<<<< HEAD
 hex-literal = "1.1"
 getrandom = { version = "0.4", features = ["sys_rng"] }
-=======
 tokio = { version = "1", features = ["macros", "rt", "test-util", "time"] }
 aws-smithy-runtime-api = { version = "1.9", features = ["client", "http-1x", "test-util"] }
->>>>>>> main

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,5 @@ quantum-box = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4"
-hex-literal = "1.1"
-getrandom = { version = "0.4", features = ["sys_rng"] }
 tokio = { version = "1", features = ["macros", "rt", "test-util", "time"] }
 aws-smithy-runtime-api = { version = "1.9", features = ["client", "http-1x", "test-util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ description = "An abstraction for building and interacting with AWS Nitro enclav
 
 [features]
 default=["http"]
-client = []
-server = ["tokio/rt"]
+client = ["dep:tokio-vsock", "dep:rmp-serde"]
+server = ["tokio/rt", "dep:tokio-vsock", "dep:rmp-serde"]
 nsm = ["nsm-types", "aws-nitro-enclaves-nsm-api/nix", "tokio/sync"]
 nsm-types = [
     "dep:sha2",
@@ -29,6 +29,7 @@ nsm-types = [
 http = ["_vsock-https"]
 channel = [
     "dep:quantum-box",
+    "dep:zeroize",
 ]
 kms = [
     "_vsock-https",
@@ -39,6 +40,7 @@ kms = [
 ]
 # The HTTPS-over-vsock transport, shared by `http` and `kms`.
 _vsock-https = [
+    "dep:tokio-vsock",
     "dep:hyper",
     "dep:rustls",
     "dep:hyper-util",
@@ -51,15 +53,15 @@ _vsock-https = [
 all-features = true
 
 [dependencies]
-const-fnv1a-hash = "1.1.0"
+const-fnv1a-hash = "1"
 serde = "1"
 tracing = "0.1"
-rmp-serde = "1"
 thiserror = "2"
-tokio-vsock = "0.7"
+rmp-serde = { version = "1", optional = true }
+tokio-vsock = { version = "0.7", optional = true }
+tokio = { version = "1", features = ["io-util"] }
 sha2 = { version = "0.10", optional = true }
 aws-types = { version = "1", optional = true }
-tokio = { version = "1", features = ["io-util"] }
 serde_bytes = { version = "0.11", optional = true }
 tower-service = { version = "0.3", optional = true }
 hyper = { version = "1.7", features = ["client"], optional = true }
@@ -92,6 +94,7 @@ rustls = { version = "0.23", optional = true, default-features = false, features
     "tls12",
 ] }
 quantum-box = { version = "0.1", optional = true }
+zeroize = { version = "1", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ let response: HealthStatus = send(connection, &HealthCheck).await?;
 
 The `channel` feature allows establishing an end-to-end encrypted channel, so a client can send data directly to the enclave without anyone else (chiefly the untrusted parent host) being able to read it. Every message is a [`quantum-box`](https://docs.rs/quantum-box) sealed box over X-Wing, a hybrid post-quantum KEM.
 
-The enclave usually generates a keypair per boot and attests its public key. The client then verifies the attestation and seals to the key it carried. Each request and mints its own response key to also receive the response encrypted.
+The enclave usually generates a keypair per boot and attests its public key. The client then verifies the attestation and seals to the key it carried. Each request mints its own response key to receive an encrypted response.
 
-The default flow looks asa follows:
+The default flow looks as follows:
 
 ```rust,ignore
 use pontifex::channel::{ChannelConsumer, ChannelDomain, ChannelEnclave};

--- a/README.md
+++ b/README.md
@@ -77,9 +77,8 @@ untrusted parent instance forwarding the bytes never sees the plaintext. Request
 (RFC 9180) `mode_base`; responses use the encapsulation construction of RFC 9458 §4.4, which
 replies to one request without a second key exchange.
 
-The enclave generates a keypair per boot and attests its public key. The client verifies the
-attestation, then seals to the key it carried. Both sides name the same `ChannelDomain`, which
-binds a protocol name and wire version into the key schedule.
+The enclave generates a keypair per boot and attests its public key; the client verifies the
+attestation and seals to the key it carried. Both sides name the same `ChannelDomain`.
 
 ```rust,ignore
 use pontifex::channel::{ChannelDomain, Requester, Responder, UnwrapErr};

--- a/README.md
+++ b/README.md
@@ -72,39 +72,33 @@ let response: HealthStatus = send(connection, &HealthCheck).await?;
 
 ### Sealed Channel
 
-The `channel` feature adds an end-to-end encrypted channel to a specific enclave boot, so the
-untrusted parent instance forwarding the bytes never sees the plaintext. Every message is a
-[`quantum-box`](https://docs.rs/quantum-box) sealed box over the X-Wing hybrid KEM.
+The `channel` feature allows establishing an end-to-end encrypted channel, so a client can send data directly to the enclave without anyone else (chiefly the untrusted parent host) being able to read it. Every message is a [`quantum-box`](https://docs.rs/quantum-box) sealed box over X-Wing, a hybrid post-quantum KEM.
 
-The enclave generates a keypair per boot and attests its public key; the client verifies the
-attestation and seals to the key it carried. Each request carries a fresh reply key the enclave
-seals the response to, so only that requester can open it. Both sides name the same
-`ChannelDomain`.
+The enclave usually generates a keypair per boot and attests its public key. The client then verifies the attestation and seals to the key it carried. Each request and mints its own response key to also receive the response encrypted.
+
+The default flow looks asa follows:
 
 ```rust,ignore
-use pontifex::channel::{ChannelDomain, Requester, Responder};
+use pontifex::channel::{ChannelConsumer, ChannelDomain, ChannelEnclave};
 
-const DOMAIN: ChannelDomain = ChannelDomain::new("my-protocol/match", 1);
+// The name is the only lever for a breaking wire change, so carry a version in it.
+const DOMAIN: ChannelDomain = ChannelDomain::new("my-protocol/match_v1");
 
-// Enclave, once per boot. Attest `responder.public_key()`.
-let responder = Responder::generate(DOMAIN)?;
+// Enclave (usually once per boot): Attest `enclave.public_key()`, then hand those bytes out.
+let enclave = ChannelEnclave::generate(DOMAIN)?;
 
-// Client, per request, against the key the verified attestation carried.
-let requester = Requester::new(DOMAIN, attested_public_key)?;
-let (sealed_request, opener) = requester.seal(b"inputs")?;
+// End consumer: uses an *attested* public key. NOTE: attestation is currently not verified here.
+let consumer = ChannelConsumer::new(DOMAIN, &attested_public_key)?;
+let (sealed_request, opener) = consumer.seal_to_enclave(b"inputs")?;
 
 // Enclave: open the request, seal the one reply it belongs to.
-let (plaintext, sealer) = responder.open(&sealed_request)?;
+let (plaintext, sealer) = enclave.open(&sealed_request)?;
 let sealed_response = sealer.seal(b"result")?;
 
-// Client: only this requester can open that response.
-let result = opener.open(&sealed_response)?;
+// End consumer: only this opener can open that response.
+let result = opener.open_from_enclave(&sealed_response)?;
 ```
-
-## Example
-
-See the [`example`](example) directory for a complete working example.
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](https://github.com/worldcoin/pontifex/blob/main/LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -73,28 +73,29 @@ let response: HealthStatus = send(connection, &HealthCheck).await?;
 ### Sealed Channel
 
 The `channel` feature adds an end-to-end encrypted channel to a specific enclave boot, so the
-untrusted parent instance forwarding the bytes never sees the plaintext. Requests use HPKE
-(RFC 9180) `mode_base`; responses use the encapsulation construction of RFC 9458 §4.4, which
-replies to one request without a second key exchange.
+untrusted parent instance forwarding the bytes never sees the plaintext. Every message is a
+[`quantum-box`](https://docs.rs/quantum-box) sealed box over the X-Wing hybrid KEM.
 
 The enclave generates a keypair per boot and attests its public key; the client verifies the
-attestation and seals to the key it carried. Both sides name the same `ChannelDomain`.
+attestation and seals to the key it carried. Each request carries a fresh reply key the enclave
+seals the response to, so only that requester can open it. Both sides name the same
+`ChannelDomain`.
 
 ```rust,ignore
-use pontifex::channel::{ChannelDomain, Requester, Responder, UnwrapErr};
+use pontifex::channel::{ChannelDomain, Requester, Responder};
 
 const DOMAIN: ChannelDomain = ChannelDomain::new("my-protocol/match", 1);
 
 // Enclave, once per boot. Attest `responder.public_key()`.
-let responder = Responder::generate(DOMAIN, &mut UnwrapErr(getrandom::SysRng));
+let responder = Responder::generate(DOMAIN)?;
 
 // Client, per request, against the key the verified attestation carried.
-let requester = Requester::from_attestation(DOMAIN, attested_public_key)?;
-let (sealed_request, opener) = requester.seal(b"inputs", &mut UnwrapErr(getrandom::SysRng))?;
+let requester = Requester::new(DOMAIN, attested_public_key)?;
+let (sealed_request, opener) = requester.seal(b"inputs")?;
 
 // Enclave: open the request, seal the one reply it belongs to.
 let (plaintext, sealer) = responder.open(&sealed_request)?;
-let sealed_response = sealer.seal(b"result", &mut UnwrapErr(getrandom::SysRng))?;
+let sealed_response = sealer.seal(b"result")?;
 
 // Client: only this requester can open that response.
 let result = opener.open(&sealed_response)?;

--- a/README.md
+++ b/README.md
@@ -70,6 +70,37 @@ let connection = ConnectionDetails::new(ENCLAVE_CID, ENCLAVE_PORT);
 let response: HealthStatus = send(connection, &HealthCheck).await?;
 ```
 
+### Sealed Channel
+
+The `channel` feature adds an end-to-end encrypted channel to a specific enclave boot, so the
+untrusted parent instance forwarding the bytes never sees the plaintext. Requests use HPKE
+(RFC 9180) `mode_base`; responses use the encapsulation construction of RFC 9458 §4.4, which
+replies to one request without a second key exchange.
+
+The enclave generates a keypair per boot and attests its public key. The client verifies the
+attestation, then seals to the key it carried. Both sides name the same `ChannelDomain`, which
+binds a protocol name and wire version into the key schedule.
+
+```rust,ignore
+use pontifex::channel::{ChannelDomain, Requester, Responder, UnwrapErr};
+
+const DOMAIN: ChannelDomain = ChannelDomain::new("my-protocol/match", 1);
+
+// Enclave, once per boot. Attest `responder.public_key()`.
+let responder = Responder::generate(DOMAIN, &mut UnwrapErr(getrandom::SysRng));
+
+// Client, per request, against the key the verified attestation carried.
+let requester = Requester::from_attestation(DOMAIN, attested_public_key)?;
+let (sealed_request, opener) = requester.seal(b"inputs", &mut UnwrapErr(getrandom::SysRng))?;
+
+// Enclave: open the request, seal the one reply it belongs to.
+let (plaintext, sealer) = responder.open(&sealed_request)?;
+let sealed_response = sealer.seal(b"result", &mut UnwrapErr(getrandom::SysRng))?;
+
+// Client: only this requester can open that response.
+let result = opener.open(&sealed_response)?;
+```
+
 ## Example
 
 See the [`example`](example) directory for a complete working example.

--- a/cspell.json
+++ b/cspell.json
@@ -1,18 +1,14 @@
 {
   "words": [
-    "aead",
-    "bhttp",
     "cbor",
     "Cose",
     "ciphertext",
-    "encapped",
-    "hkdf",
+    "csprng",
     "hpke",
-    "getrandom",
     "rustls",
     "thiserror",
+    "unseal",
     "vsock",
-    "webpki",
-    "zeroize"
+    "webpki"
   ]
 }

--- a/cspell.json
+++ b/cspell.json
@@ -1,3 +1,18 @@
 {
-  "words": ["cbor", "Cose", "rustls", "thiserror", "vsock", "webpki"]
+  "words": [
+    "aead",
+    "bhttp",
+    "cbor",
+    "Cose",
+    "ciphertext",
+    "encapped",
+    "hkdf",
+    "hpke",
+    "getrandom",
+    "rustls",
+    "thiserror",
+    "vsock",
+    "webpki",
+    "zeroize"
+  ]
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,19 +1,27 @@
-//! A confidential channel to a specific, measured enclave.
+//! A confidential channel between an enclave and a consumer.
 //!
-//! Every message is a [`quantum_box`] sealed box — an anonymous HPKE seal over the X-Wing hybrid
-//! KEM — so the untrusted parent instance forwarding the bytes never sees plaintext.
+//! Enables a consumer to encrypt an arbitrary payload so only the enclave can read it. The consumer
+//! also provides a key to receive an end-to-end encrypted response.
 //!
-//! The enclave generates a [`Responder`] per boot and attests its public key. A client verifies
-//! the attestation, builds a [`Requester`] from the attested key, and seals to it. Each request
-//! carries a fresh reply key that the enclave seals the one matching response to, so the response
-//! needs no second round trip and only that requester can open it.
+//! Uses a `quantum_box` under the hood, which uses HPKE with X-Wing (Kyber KEM) for post-quantum hybrid
+//! security.
 //!
-//! Both sides must name the same [`ChannelDomain`], which is bound into every seal.
+//!
+//! # Important
+//! 1. The enclave's seal key MUST remain in the enclave.
+//! 2. The response from the enclave is **NOT** attested. Quantum boxes are anonymous, anyone
+//!   could have encrypted a response to it with its public key. If the use case requires trusting
+//!   the enclave response, add an additional attestation or signature mechanism.
+//! 3. This module currently does **NOT** verify an attestation on the enclave's public key.
 
 use quantum_box::{PublicKey, SecretKey};
+use zeroize::ZeroizeOnDrop;
+
+pub use quantum_box::Error as SealedBoxError;
+pub use zeroize::Zeroizing;
 
 /// Length of an X-Wing encapsulation key: ML-KEM-768 (1184) plus X25519 (32).
-const REPLY_KEY_LEN: usize = 1216;
+const RESPONSE_KEY_LEN: usize = 1216;
 
 // Bound into the `info` so one key is never used for both directions.
 const REQUEST: u8 = 0;
@@ -22,47 +30,56 @@ const RESPONSE: u8 = 1;
 /// Why a channel operation did not complete.
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ChannelError {
-	/// The request opened, but was too short to carry a reply key.
-	#[error("ChannelError::MissingReplyKey")]
-	MissingReplyKey,
+	/// The request opened, but was too short to carry a response key.
+	#[error("ChannelError::MissingResponseKey")]
+	MissingResponseKey,
+	/// The request carried a response key that is not a valid X-Wing encapsulation key.
+	#[error("ChannelError::MalformedResponseKey")]
+	MalformedResponseKey,
 	/// A key, a seal, or an unseal failed.
 	#[error("ChannelError::SealedBox: {0}")]
-	SealedBox(#[from] quantum_box::Error),
+	SealedBox(#[from] SealedBoxError),
 }
 
-/// A protocol name and the version of its wire contract, both bound into every seal.
+/// The protocol name bound into every seal on a channel.
 ///
-/// Name one protocol per domain and never reuse it. Bumping the version fails every message
-/// sealed under the old number, which is the lever for a breaking change to the sealed bytes.
+/// A client and enclave that disagree on the name fail closed instead of exchanging plaintext.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ChannelDomain {
 	name: &'static str,
-	version: u8,
 }
 
 impl ChannelDomain {
-	/// Names a channel domain at a wire version.
+	/// Names a channel domain. A good idea is to anchor it on the enclave's `module_id` (e.g. hash).
 	#[must_use]
-	pub const fn new(name: &'static str, version: u8) -> Self {
-		Self { name, version }
+	pub const fn new(name: &'static str) -> Self {
+		Self { name }
 	}
 
 	fn info(&self, direction: u8) -> Vec<u8> {
 		let mut info = self.name.as_bytes().to_vec();
-		info.push(self.version);
 		info.push(direction);
 		info
 	}
 }
 
-/// Responder-side boot keypair: opens sealed requests and seals the matching responses.
-pub struct Responder {
+impl ZeroizeOnDrop for ChannelEnclave {}
+impl ZeroizeOnDrop for ResponseOpener {} // remember to update if adding more secret info which is not a `SecretKey`
+
+const _: () = {
+	// Ensures ZeroizeOnDrop is present for `SecretKey`
+	const fn assert_zeroize_on_drop<T: ZeroizeOnDrop>() {}
+	assert_zeroize_on_drop::<SecretKey>();
+};
+
+/// The enclave side of a channel. Opens sealed requests and seals the matching responses.
+pub struct ChannelEnclave {
 	domain: ChannelDomain,
 	secret_key: SecretKey,
 }
 
-impl Responder {
-	/// Generates a fresh keypair serving `domain`.
+impl ChannelEnclave {
+	/// Generates a fresh keypair serving `domain`, once per boot.
 	///
 	/// # Errors
 	///
@@ -74,298 +91,453 @@ impl Responder {
 		})
 	}
 
-	/// The public key requesters seal to for this boot. Attest these bytes.
+	/// The public key to which consumers seal.
 	#[must_use]
 	pub fn public_key(&self) -> Vec<u8> {
 		self.secret_key.public_key().to_bytes()
 	}
 
-	/// Opens a sealed request, returning the plaintext and a sealer for its one response.
+	/// Opens a sealed request, returning the plaintext and the sealer for its one response.
 	///
 	/// # Errors
 	///
-	/// Fails if the request was not sealed to this boot under this domain, or carries no reply
-	/// key.
-	pub fn open(&self, request: &[u8]) -> Result<(Vec<u8>, ResponseSealer), ChannelError> {
-		let body = SecretKey::unseal(&self.secret_key, request, Some(&self.domain.info(REQUEST)))?;
-		let Some((reply_key, plaintext)) = body.split_first_chunk::<REPLY_KEY_LEN>() else {
-			return Err(ChannelError::MissingReplyKey);
+	/// Fails if the request was not sealed properly or carries no response key.
+	pub fn open(
+		&self,
+		request: &[u8],
+	) -> Result<(Zeroizing<Vec<u8>>, ResponseSealer), ChannelError> {
+		let body = Zeroizing::new(SecretKey::unseal(
+			&self.secret_key,
+			request,
+			Some(&self.domain.info(REQUEST)),
+		)?);
+		let Some((response_key, plaintext)) = body.split_first_chunk::<RESPONSE_KEY_LEN>() else {
+			return Err(ChannelError::MissingResponseKey);
 		};
+		let response_key =
+			PublicKey::from_bytes(response_key).map_err(|_| ChannelError::MalformedResponseKey)?;
 
 		Ok((
-			plaintext.to_vec(),
+			Zeroizing::new(plaintext.to_vec()),
 			ResponseSealer {
 				domain: self.domain,
-				reply_key: PublicKey::from_bytes(reply_key)?,
+				response_key,
 			},
 		))
 	}
 }
 
-/// Requester-side handle built from an attested encryption key.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Requester {
-	domain: ChannelDomain,
-	public_key: PublicKey,
-}
-
-impl Requester {
-	/// Builds a requester for the public key a verified attestation carried.
-	///
-	/// # Errors
-	///
-	/// Fails if `public_key` is not a valid X-Wing encapsulation key.
-	pub fn new(domain: ChannelDomain, public_key: &[u8]) -> Result<Self, ChannelError> {
-		Ok(Self {
-			domain,
-			public_key: PublicKey::from_bytes(public_key)?,
-		})
-	}
-
-	/// Seals one request, returning the wire bytes and an opener for its one response.
-	///
-	/// # Errors
-	///
-	/// Fails if the operating system CSPRNG is unavailable, or the box refuses to seal.
-	pub fn seal(&self, plaintext: &[u8]) -> Result<(Vec<u8>, ResponseOpener), ChannelError> {
-		let reply_key = SecretKey::generate()?;
-		let mut body = reply_key.public_key().to_bytes();
-		body.extend_from_slice(plaintext);
-
-		let request = PublicKey::seal(&self.public_key, &body, Some(&self.domain.info(REQUEST)))?;
-
-		Ok((
-			request,
-			ResponseOpener {
-				domain: self.domain,
-				reply_key,
-			},
-		))
-	}
-}
-
-/// Opens the one response belonging to a [`Requester::seal`] call.
-pub struct ResponseOpener {
-	domain: ChannelDomain,
-	reply_key: SecretKey,
-}
-
-impl ResponseOpener {
-	/// Opens a sealed response.
-	///
-	/// # Errors
-	///
-	/// Fails if the response was not sealed to this request.
-	pub fn open(&self, response: &[u8]) -> Result<Vec<u8>, ChannelError> {
-		Ok(SecretKey::unseal(
-			&self.reply_key,
-			response,
-			Some(&self.domain.info(RESPONSE)),
-		)?)
-	}
-}
-
-/// Seals the one response belonging to a [`Responder::open`] call.
+/// Seals a one-time response back to the consumer.
+///
+/// # Important
+/// The sealed response is **NOT** attested by the enclave, and anyone could generate
+/// a valid ciphertext for the consumer's public key. If the use case requires the response
+/// to be trusted, add an additional attestation/signature to the response.
 pub struct ResponseSealer {
 	domain: ChannelDomain,
-	reply_key: PublicKey,
+	response_key: PublicKey,
+}
+
+impl std::fmt::Debug for ResponseSealer {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ResponseSealer").finish_non_exhaustive()
+	}
 }
 
 impl ResponseSealer {
-	/// Seals one response.
+	/// Seals the response to the key its request carried.
 	///
 	/// # Errors
 	///
-	/// Fails if the operating system CSPRNG is unavailable, or the box refuses to seal.
+	/// Fails if the operating system CSPRNG is unavailable, or sealing unexpectedly fails.
 	pub fn seal(self, plaintext: &[u8]) -> Result<Vec<u8>, ChannelError> {
 		Ok(PublicKey::seal(
-			&self.reply_key,
+			&self.response_key,
 			plaintext,
 			Some(&self.domain.info(RESPONSE)),
 		)?)
 	}
 }
 
+/// The consumer side of a channel, which seals requests to one attested enclave boot.
+///
+/// Holds no secret: the response key belongs to the [`ResponseOpener`] each seal returns.
+#[derive(Clone)]
+pub struct ChannelConsumer {
+	domain: ChannelDomain,
+	enclave_public_key: PublicKey,
+}
+
+impl std::fmt::Debug for ChannelConsumer {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("ChannelConsumer")
+			.field("domain", &self.domain)
+			.finish_non_exhaustive()
+	}
+}
+
+impl ChannelConsumer {
+	/// Builds a consumer for the public key a verified attestation carried.
+	///
+	/// This does **not** verify that attestation. Verify it first — otherwise the key may be the
+	/// untrusted parent's own, and it will read every request.
+	///
+	/// # Errors
+	///
+	/// Fails if `enclave_public_key` is not a valid X-Wing encapsulation key.
+	pub fn new(domain: ChannelDomain, enclave_public_key: &[u8]) -> Result<Self, ChannelError> {
+		Ok(Self {
+			domain,
+			enclave_public_key: PublicKey::from_bytes(enclave_public_key)?,
+		})
+	}
+
+	/// Seals one request, returning the ciphertext bytes and the opener for its one response.
+	///
+	/// # Errors
+	///
+	/// Fails if the operating system CSPRNG is unavailable, or an unxpected seal error.
+	pub fn seal_to_enclave(
+		&self,
+		plaintext: &[u8],
+	) -> Result<(Vec<u8>, ResponseOpener), ChannelError> {
+		let response_sk = SecretKey::generate()?;
+
+		let mut body = Zeroizing::new(Vec::with_capacity(RESPONSE_KEY_LEN + plaintext.len()));
+		body.extend_from_slice(&response_sk.public_key().to_bytes());
+		body.extend_from_slice(plaintext);
+
+		let request = PublicKey::seal(
+			&self.enclave_public_key,
+			&body,
+			Some(&self.domain.info(REQUEST)),
+		)?;
+
+		Ok((
+			request,
+			ResponseOpener {
+				domain: self.domain,
+				response_sk,
+			},
+		))
+	}
+}
+
+/// Opens the response from the enclave after a [`ChannelConsumer::seal_to_enclave`] call. One-time use.
+///
+/// ```compile_fail,E0382
+/// # use pontifex::channel::{ChannelConsumer, ChannelDomain, ChannelEnclave};
+/// # const DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/doc");
+/// # let enclave = ChannelEnclave::generate(DOMAIN)?;
+/// # let consumer = ChannelConsumer::new(DOMAIN, &enclave.public_key())?;
+/// # let (request, opener) = consumer.seal_to_enclave(b"inputs")?;
+/// # let (_, sealer) = enclave.open(&request)?;
+/// # let response = sealer.seal(b"result")?;
+/// opener.open_from_enclave(&response)?;
+/// opener.open_from_enclave(&response)?; // the opener was consumed above
+/// # Ok::<(), pontifex::ChannelError>(())
+/// ```
+#[derive(Debug)]
+pub struct ResponseOpener {
+	domain: ChannelDomain,
+	response_sk: SecretKey,
+}
+
+impl ResponseOpener {
+	/// Opens the response to this request. Key is zeroized after use.
+	///
+	/// # Errors
+	///
+	/// Fails if the response was not sealed to this request under this domain. Retry by sealing
+	/// a fresh request; the key for these bytes is gone.
+	pub fn open_from_enclave(self, response: &[u8]) -> Result<Zeroizing<Vec<u8>>, ChannelError> {
+		Ok(Zeroizing::new(SecretKey::unseal(
+			&self.response_sk,
+			response,
+			Some(&self.domain.info(RESPONSE)),
+		)?))
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::{
-		ChannelDomain, ChannelError, REPLY_KEY_LEN, REQUEST, RESPONSE, Requester, Responder,
+		ChannelConsumer, ChannelDomain, ChannelEnclave, ChannelError, REQUEST, RESPONSE,
+		RESPONSE_KEY_LEN, ResponseOpener, SealedBoxError,
 	};
-	use quantum_box::{Error, SecretKey};
+	use quantum_box::{PublicKey, SecretKey};
 
-	const TEST_DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/test", 1);
+	const TEST_DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/test");
 
-	fn responder() -> Responder {
-		Responder::generate(TEST_DOMAIN).expect("CSPRNG available")
+	fn enclave() -> ChannelEnclave {
+		ChannelEnclave::generate(TEST_DOMAIN).expect("CSPRNG available")
 	}
 
-	fn requester_for(responder: &Responder, domain: ChannelDomain) -> Requester {
-		Requester::new(domain, &responder.public_key()).expect("attested key parses")
+	fn consumer_for(enclave: &ChannelEnclave, domain: ChannelDomain) -> ChannelConsumer {
+		ChannelConsumer::new(domain, &enclave.public_key()).expect("attested key parses")
+	}
+
+	fn seal(consumer: &ChannelConsumer, plaintext: &[u8]) -> (Vec<u8>, ResponseOpener) {
+		consumer.seal_to_enclave(plaintext).expect("seal")
+	}
+
+	fn seal_raw_body(enclave: &ChannelEnclave, body: &[u8]) -> Vec<u8> {
+		PublicKey::seal(
+			&enclave.secret_key.public_key(),
+			body,
+			Some(&TEST_DOMAIN.info(REQUEST)),
+		)
+		.expect("seal")
 	}
 
 	#[test]
 	fn round_trips_a_request_and_its_response() {
-		let responder = responder();
-		let (request, opener) = requester_for(&responder, TEST_DOMAIN)
-			.seal(b"inputs")
-			.expect("seal");
+		let enclave = enclave();
+		let (request, opener) = seal(&consumer_for(&enclave, TEST_DOMAIN), b"inputs");
 
-		let (plaintext, sealer) = responder.open(&request).expect("open");
-		assert_eq!(plaintext, b"inputs");
+		let (plaintext, sealer) = enclave.open(&request).expect("open");
+		assert_eq!(plaintext.as_slice(), b"inputs");
 
 		let response = sealer.seal(b"result").expect("seal response");
-		assert_eq!(opener.open(&response).expect("open response"), b"result");
+		assert_eq!(
+			opener
+				.open_from_enclave(&response)
+				.expect("open response")
+				.as_slice(),
+			b"result"
+		);
 	}
 
-	/// Guards the framing constant against an X-Wing key size change upstream.
 	#[test]
-	fn a_reply_key_is_exactly_the_framed_length() {
+	fn round_trips_an_empty_body_in_both_directions() {
+		let enclave = enclave();
+		let (request, opener) = seal(&consumer_for(&enclave, TEST_DOMAIN), b"");
+
+		let (plaintext, sealer) = enclave.open(&request).expect("open");
+		assert!(plaintext.is_empty());
+
+		let response = sealer.seal(b"").expect("seal response");
+		assert!(
+			opener
+				.open_from_enclave(&response)
+				.expect("open response")
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn an_opener_rejects_the_response_to_another_request() {
+		let enclave = enclave();
+		let consumer = consumer_for(&enclave, TEST_DOMAIN);
+
+		let (first, first_opener) = seal(&consumer, b"transfer 10");
+		let (second, _) = seal(&consumer, b"transfer 10000");
+
+		let (_, first_sealer) = enclave.open(&first).expect("open first");
+		let (_, second_sealer) = enclave.open(&second).expect("open second");
+		assert_ne!(
+			first_sealer.response_key.to_bytes(),
+			second_sealer.response_key.to_bytes(),
+			"each request must mint its own response key"
+		);
+
+		let substituted = second_sealer.seal(b"ok").expect("seal response");
+		assert_eq!(
+			first_opener.open_from_enclave(&substituted).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Unseal))
+		);
+	}
+
+	#[test]
+	fn a_response_key_is_exactly_the_framed_length() {
 		let key = SecretKey::from_seed(&[0u8; 32]).public_key().to_bytes();
-		assert_eq!(key.len(), REPLY_KEY_LEN);
+		assert_eq!(key.len(), RESPONSE_KEY_LEN);
 	}
 
 	#[test]
-	fn info_binds_name_version_and_direction() {
+	fn info_binds_name_and_direction() {
 		assert_eq!(
 			TEST_DOMAIN.info(REQUEST),
-			[b"pontifex/test".as_ref(), &[1, REQUEST]].concat()
+			[b"pontifex/test".as_ref(), &[REQUEST]].concat()
 		);
 		assert_ne!(TEST_DOMAIN.info(REQUEST), TEST_DOMAIN.info(RESPONSE));
 		assert_ne!(
 			TEST_DOMAIN.info(REQUEST),
-			ChannelDomain::new("pontifex/other", 1).info(REQUEST)
-		);
-		assert_ne!(
-			TEST_DOMAIN.info(REQUEST),
-			ChannelDomain::new("pontifex/test", 2).info(REQUEST)
+			ChannelDomain::new("pontifex/other").info(REQUEST)
 		);
 	}
 
 	#[test]
-	fn rejects_an_unparseable_attested_key() {
+	fn rejects_an_unparseable_key() {
 		assert_eq!(
-			Requester::new(TEST_DOMAIN, &[0u8; 32]),
-			Err(ChannelError::SealedBox(Error::KeyFormat))
+			ChannelConsumer::new(TEST_DOMAIN, &[0u8; 32]).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::KeyFormat))
 		);
 	}
 
 	#[test]
-	fn rejects_a_request_sealed_to_another_boot() {
-		let (request, _) = requester_for(&responder(), TEST_DOMAIN)
-			.seal(b"inputs")
-			.expect("seal");
+	fn rejects_a_request_sealed_to_another_key() {
+		let (request, _) = seal(&consumer_for(&enclave(), TEST_DOMAIN), b"inputs");
 
 		assert_eq!(
-			responder().open(&request).err(),
-			Some(ChannelError::SealedBox(Error::Unseal))
+			enclave().open(&request).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Unseal))
 		);
 	}
 
 	#[test]
 	fn rejects_a_request_sealed_under_another_domain() {
-		let responder = responder();
-		for domain in [
-			ChannelDomain::new("pontifex/other", 1),
-			ChannelDomain::new("pontifex/test", 2),
-		] {
-			let (request, _) = requester_for(&responder, domain)
-				.seal(b"inputs")
-				.expect("seal");
-			assert_eq!(
-				responder.open(&request).err(),
-				Some(ChannelError::SealedBox(Error::Unseal)),
-				"{domain:?}"
-			);
-		}
+		let enclave = enclave();
+		let (request, _) = seal(
+			&consumer_for(&enclave, ChannelDomain::new("pontifex/other")),
+			b"inputs",
+		);
+
+		assert_eq!(
+			enclave.open(&request).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Unseal))
+		);
 	}
 
 	#[test]
 	fn rejects_a_tampered_request() {
-		let responder = responder();
-		let (mut request, _) = requester_for(&responder, TEST_DOMAIN)
-			.seal(b"inputs")
-			.expect("seal");
+		let enclave = enclave();
+		let (mut request, _) = seal(&consumer_for(&enclave, TEST_DOMAIN), b"inputs");
 		*request.last_mut().expect("non-empty") ^= 0x01;
 
 		assert_eq!(
-			responder.open(&request).err(),
-			Some(ChannelError::SealedBox(Error::Unseal))
+			enclave.open(&request).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Unseal))
 		);
 	}
 
 	#[test]
 	fn rejects_a_truncated_request() {
 		assert_eq!(
-			responder().open(&[]).err(),
-			Some(ChannelError::SealedBox(Error::EmptyCiphertext))
+			enclave().open(&[]).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::EmptyCiphertext))
 		);
 		assert_eq!(
-			responder().open(b"short").err(),
-			Some(ChannelError::SealedBox(Error::Decode))
+			enclave().open(b"short").err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Decode))
 		);
 	}
 
-	/// The boot's key is public, so any sender can seal a body too short to carry a reply key.
 	#[test]
-	fn rejects_a_request_carrying_no_reply_key() {
-		let responder = responder();
-		let request = quantum_box::PublicKey::seal(
-			&responder.secret_key.public_key(),
-			b"no reply key here",
-			Some(&TEST_DOMAIN.info(REQUEST)),
-		)
-		.expect("seal");
+	fn rejects_a_request_carrying_no_response_key() {
+		let enclave = enclave();
+
+		for body in [
+			b"".as_ref(),
+			b"no response key here".as_ref(),
+			&[0u8; RESPONSE_KEY_LEN - 1],
+		] {
+			let request = seal_raw_body(&enclave, body);
+			assert_eq!(
+				enclave.open(&request).err(),
+				Some(ChannelError::MissingResponseKey),
+				"body of {} bytes",
+				body.len()
+			);
+		}
+	}
+
+	#[test]
+	fn rejects_a_request_carrying_a_malformed_response_key() {
+		let enclave = enclave();
+		let request = seal_raw_body(&enclave, &[0xFF; RESPONSE_KEY_LEN]);
 
 		assert_eq!(
-			responder.open(&request).err(),
-			Some(ChannelError::MissingReplyKey)
+			enclave.open(&request).err(),
+			Some(ChannelError::MalformedResponseKey)
 		);
 	}
 
 	#[test]
 	fn rejects_a_tampered_response() {
-		let responder = responder();
-		let (request, opener) = requester_for(&responder, TEST_DOMAIN)
-			.seal(b"inputs")
-			.expect("seal");
-		let (_, sealer) = responder.open(&request).expect("open");
+		let enclave = enclave();
+		let (request, opener) = seal(&consumer_for(&enclave, TEST_DOMAIN), b"inputs");
 
+		let (_, sealer) = enclave.open(&request).expect("open");
 		let mut response = sealer.seal(b"result").expect("seal response");
 		*response.last_mut().expect("non-empty") ^= 0x01;
 
 		assert_eq!(
-			opener.open(&response),
-			Err(ChannelError::SealedBox(Error::Unseal))
+			opener.open_from_enclave(&response).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Unseal))
 		);
 	}
 
 	#[test]
-	fn another_requester_cannot_open_a_response() {
-		let responder = responder();
-		let requester = requester_for(&responder, TEST_DOMAIN);
-		let (request, _) = requester.seal(b"inputs").expect("seal");
-		let (_, eavesdropper) = requester.seal(b"unrelated").expect("seal");
-
-		let (_, sealer) = responder.open(&request).expect("open");
-		let response = sealer.seal(b"result").expect("seal response");
+	fn rejects_a_truncated_response() {
+		let enclave = enclave();
+		let (_, opener) = seal(&consumer_for(&enclave, TEST_DOMAIN), b"inputs");
 
 		assert_eq!(
-			eavesdropper.open(&response),
-			Err(ChannelError::SealedBox(Error::Unseal))
+			opener.open_from_enclave(&[]).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::EmptyCiphertext))
 		);
 	}
 
 	#[test]
-	fn separate_boots_advertise_separate_keys() {
-		assert_ne!(responder().public_key(), responder().public_key());
+	fn rejects_a_response_sealed_under_the_request_direction() {
+		let enclave = enclave();
+		let (_, opener) = seal(&consumer_for(&enclave, TEST_DOMAIN), b"inputs");
+
+		let response = PublicKey::seal(
+			&opener.response_sk.public_key(),
+			b"result",
+			Some(&TEST_DOMAIN.info(REQUEST)),
+		)
+		.expect("seal");
+
+		assert_eq!(
+			opener.open_from_enclave(&response).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Unseal))
+		);
+	}
+
+	#[test]
+	fn rejects_a_response_sealed_under_another_domain() {
+		let enclave = enclave();
+		let (_, opener) = seal(&consumer_for(&enclave, TEST_DOMAIN), b"inputs");
+
+		let response = PublicKey::seal(
+			&opener.response_sk.public_key(),
+			b"result",
+			Some(&ChannelDomain::new("pontifex/other").info(RESPONSE)),
+		)
+		.expect("seal");
+
+		assert_eq!(
+			opener.open_from_enclave(&response).err(),
+			Some(ChannelError::SealedBox(SealedBoxError::Unseal))
+		);
+	}
+
+	#[test]
+	fn keys_are_generated_randomly() {
+		assert_ne!(enclave().public_key(), enclave().public_key());
 	}
 
 	#[test]
 	fn sealing_the_same_plaintext_twice_yields_different_bytes() {
-		let requester = requester_for(&responder(), TEST_DOMAIN);
-		let (first, _) = requester.seal(b"inputs").expect("seal");
-		let (second, _) = requester.seal(b"inputs").expect("seal");
+		let consumer = consumer_for(&enclave(), TEST_DOMAIN);
 
-		assert_ne!(first, second);
+		assert_ne!(seal(&consumer, b"inputs").0, seal(&consumer, b"inputs").0);
+	}
+
+	#[test]
+	fn key_types_do_not_print_their_keys() {
+		let enclave = enclave();
+		let consumer = consumer_for(&enclave, TEST_DOMAIN);
+		let (request, _) = seal(&consumer, b"inputs");
+		let (_, sealer) = enclave.open(&request).expect("open");
+
+		assert_eq!(
+			format!("{consumer:?}"),
+			r#"ChannelConsumer { domain: ChannelDomain { name: "pontifex/test" }, .. }"#
+		);
+		assert_eq!(format!("{sealer:?}"), "ResponseSealer { .. }");
 	}
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,1023 @@
+//! A confidential channel to a specific, measured enclave.
+//!
+//! Requests use [RFC 9180](https://datatracker.ietf.org/doc/rfc9180/) `mode_base` directly.
+//! Responses use the encapsulation construction of
+//! [RFC 9458 §4.4](https://datatracker.ietf.org/doc/rfc9458/) — Oblivious HTTP — because it
+//! solves exactly the problem a request-response enclave path has: replying to one HPKE request
+//! without a second key exchange, and without reusing the request context in reverse, which
+//! RFC 9180 §9.8 forbids.
+//!
+//! Both halves live in one module so the tests exercise the same code the enclave and the client
+//! each run, rather than a test-only reimplementation of one side.
+//!
+//! # Domain separation
+//!
+//! Every channel is opened under a [`ChannelDomain`], which the caller owns: a protocol name and
+//! a wire version. Both are bound into the HPKE `info`, and the name also derives the response
+//! exporter label, so two protocols sharing one enclave keypair cannot open each other's
+//! messages and a version bump fails at channel setup rather than as a misparse.
+//!
+//! # Relationship to RFC 9458 §4.4
+//!
+//! Followed as written. The one substitution is the caller's exporter label (see
+//! [`ChannelDomain`]) in place of `"message/bhttp response"`. §4.4 step 1 points at §4.6,
+//! *Repurposing the Encapsulation Format*, for alternative message formats, and §6.4, *Key
+//! Management*, adds that the label was chosen for symmetry only and that designers reusing the
+//! format should pick a different one for key diversity. No BHTTP is carried here, so this is a
+//! substitution the RFC directs rather than a deviation from it.
+
+use aes_gcm::{
+	Aes256Gcm, Key, KeyInit,
+	aead::{Aead, Nonce},
+};
+use channel_sha2::Sha256;
+use hkdf::Hkdf;
+use hpke::{
+	Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable, aead::AeadCtxS,
+	rand_core::CryptoRng, setup_receiver, setup_sender_with_rng,
+};
+use zeroize::Zeroizing;
+
+/// The RNG traits the channel seals and generates against, re-exported so callers bind against
+/// the same generation this crate does.
+pub use hpke::rand_core;
+pub use hpke::rand_core::UnwrapErr;
+
+/// The channel ciphersuite, pinned at the type level so it cannot drift silently:
+/// DHKEM(X25519, HKDF-SHA256) — RFC 9180 §7.1.
+type Kem = hpke::kem::X25519HkdfSha256;
+/// HKDF-SHA256 — RFC 9180 §7.2.
+type Kdf = hpke::kdf::HkdfSha256;
+/// AES-256-GCM — RFC 9180 §7.3, AEAD id `0x0002`.
+type ChannelAead = hpke::aead::AesGcm256;
+
+/// Length of an X25519 public key, which is what an enclave attests.
+pub const ENCRYPTION_KEY_LEN: usize = 32;
+
+/// Suffix appended to a [`ChannelDomain`]'s name to form the response exporter label.
+const EXPORTER_LABEL_SUFFIX: &[u8] = b" response";
+
+/// `Expand` info for the response AEAD key — RFC 9458 §4.4 step 4.
+const INFO_KEY: &[u8] = b"key";
+
+/// `Expand` info for the response AEAD nonce — RFC 9458 §4.4 step 5.
+const INFO_NONCE: &[u8] = b"nonce";
+
+/// Length of an HPKE encapsulated key under DHKEM(X25519, HKDF-SHA256) — RFC 9180 §7.1.
+const ENCAPSULATED_KEY_LEN: usize = 32;
+
+/// AES-256-GCM key length — RFC 9180 §7.3 `Nk`.
+const AEAD_KEY_LEN: usize = 32;
+
+/// AES-256-GCM nonce length — RFC 9180 §7.3 `Nn`.
+const AEAD_NONCE_LEN: usize = 12;
+
+/// GCM authentication tag length — RFC 9180 §7.3 `Nt`.
+const AEAD_TAG_LEN: usize = 16;
+
+/// `max(Nn, Nk)`, the length RFC 9458 §4.4 uses for both the exported secret (step 1) and the
+/// `response_nonce` (step 2).
+const RESPONSE_NONCE_LEN: usize = if AEAD_NONCE_LEN > AEAD_KEY_LEN {
+	AEAD_NONCE_LEN
+} else {
+	AEAD_KEY_LEN
+};
+
+const _: () = assert!(RESPONSE_NONCE_LEN >= AEAD_KEY_LEN);
+const _: () = assert!(RESPONSE_NONCE_LEN >= AEAD_NONCE_LEN);
+
+/// Why a channel operation did not complete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChannelError {
+	/// A wire body was too short to hold its framing, a tag, and any plaintext.
+	Truncated,
+	/// The encapsulated key was malformed, or yielded the all-zero shared secret that
+	/// RFC 9180 §7.1.4 requires the KEM to abort on.
+	InvalidEncapsulatedKey,
+	/// The advertised encryption public key was not a valid X25519 point.
+	InvalidEncryptionKey,
+	/// The ciphertext failed authentication under the derived key.
+	OpenFailed,
+	/// Exporting the response secret from the request context failed — RFC 9458 §4.4 step 1.
+	ExportFailed,
+	/// Deriving the response AEAD key or nonce failed — RFC 9458 §4.4 steps 3 to 5.
+	DeriveFailed,
+	/// The AEAD refused to seal, which a well-formed key and nonce make unreachable.
+	SealFailed,
+}
+
+/// What a channel is opened for: a protocol name and the version of its wire contract.
+///
+/// The name is the caller's domain-separation string — pick one that identifies the protocol,
+/// not the crate, and never reuse it across protocols. Both fields are bound into the HPKE
+/// `info`, and the name derives the RFC 9458 §4.4 exporter label as `"<name> response"`.
+///
+/// Bumping [`version`](Self::version) makes every channel under the old number fail at setup, so
+/// it is the lever for a breaking change to whatever the sealed bytes mean.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChannelDomain {
+	name: &'static str,
+	version: u8,
+}
+
+impl ChannelDomain {
+	/// Names a channel domain at a wire version.
+	#[must_use]
+	pub const fn new(name: &'static str, version: u8) -> Self {
+		Self { name, version }
+	}
+
+	/// Returns the protocol name.
+	#[must_use]
+	pub const fn name(&self) -> &'static str {
+		self.name
+	}
+
+	/// Returns the wire version bound into every channel under this domain.
+	#[must_use]
+	pub const fn version(&self) -> u8 {
+		self.version
+	}
+
+	/// HPKE `info`: name, wire version, and responder public key.
+	///
+	/// Both sides bind this into the key schedule, so a mismatched domain, version or boot fails
+	/// at setup rather than decrypting garbage.
+	fn info(&self, encryption_public_key: &[u8; ENCRYPTION_KEY_LEN]) -> Vec<u8> {
+		let name = self.name.as_bytes();
+		let mut info = Vec::with_capacity(name.len() + 1 + encryption_public_key.len());
+		info.extend_from_slice(name);
+		info.push(self.version);
+		info.extend_from_slice(encryption_public_key);
+		info
+	}
+
+	/// Exporter context for the response secret — RFC 9458 §4.4 step 1.
+	fn exporter_label(&self) -> Vec<u8> {
+		let name = self.name.as_bytes();
+		let mut label = Vec::with_capacity(name.len() + EXPORTER_LABEL_SUFFIX.len());
+		label.extend_from_slice(name);
+		label.extend_from_slice(EXPORTER_LABEL_SUFFIX);
+		label
+	}
+}
+
+/// A sealed request on the wire: `enc || ciphertext`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SealedRequest(Vec<u8>);
+
+impl SealedRequest {
+	/// Wraps request bytes. Validation happens in [`Responder::open`].
+	#[must_use]
+	pub fn from_bytes(bytes: impl Into<Vec<u8>>) -> Self {
+		Self(bytes.into())
+	}
+
+	/// Returns the raw wire bytes.
+	#[must_use]
+	pub fn into_bytes(self) -> Vec<u8> {
+		self.0
+	}
+}
+
+impl AsRef<[u8]> for SealedRequest {
+	fn as_ref(&self) -> &[u8] {
+		&self.0
+	}
+}
+
+/// A sealed response on the wire: `response_nonce || ciphertext`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SealedResponse(Vec<u8>);
+
+impl SealedResponse {
+	/// Wraps response bytes. Validation happens in [`ResponseOpener::open`].
+	#[must_use]
+	pub fn from_bytes(bytes: impl Into<Vec<u8>>) -> Self {
+		Self(bytes.into())
+	}
+
+	/// Returns the raw wire bytes.
+	#[must_use]
+	pub fn into_bytes(self) -> Vec<u8> {
+		self.0
+	}
+}
+
+impl AsRef<[u8]> for SealedResponse {
+	fn as_ref(&self) -> &[u8] {
+		&self.0
+	}
+}
+
+type ResponseSecret = Zeroizing<[u8; RESPONSE_NONCE_LEN]>;
+
+/// The `Extract`/`Expand` chain of RFC 9458 §4.4 steps 3 to 5, returning raw key material.
+///
+/// Split from [`derive_response_aead`] so a known-answer test can pin the derived bytes against
+/// an independently computed vector; production code never sees the raw key outside this file.
+fn derive_response_key_nonce(
+	secret: &ResponseSecret,
+	encapsulated_key: &[u8; ENCAPSULATED_KEY_LEN],
+	response_nonce: &[u8; RESPONSE_NONCE_LEN],
+) -> Result<(Zeroizing<[u8; AEAD_KEY_LEN]>, [u8; AEAD_NONCE_LEN]), ChannelError> {
+	let mut salt = Vec::with_capacity(ENCAPSULATED_KEY_LEN + RESPONSE_NONCE_LEN);
+	salt.extend_from_slice(encapsulated_key);
+	salt.extend_from_slice(response_nonce);
+
+	let hkdf = Hkdf::<Sha256>::new(Some(&salt), secret.as_slice());
+
+	let mut key = Zeroizing::new([0u8; AEAD_KEY_LEN]);
+	let mut nonce = [0u8; AEAD_NONCE_LEN];
+	hkdf.expand(INFO_KEY, key.as_mut_slice())
+		.and_then(|()| hkdf.expand(INFO_NONCE, &mut nonce))
+		.map_err(|_| ChannelError::DeriveFailed)?;
+
+	Ok((key, nonce))
+}
+
+fn derive_response_aead(
+	secret: &ResponseSecret,
+	encapsulated_key: &[u8; ENCAPSULATED_KEY_LEN],
+	response_nonce: &[u8; RESPONSE_NONCE_LEN],
+) -> Result<(Aes256Gcm, Nonce<Aes256Gcm>), ChannelError> {
+	let (key, nonce) = derive_response_key_nonce(secret, encapsulated_key, response_nonce)?;
+
+	Ok((
+		Aes256Gcm::new(&Key::<Aes256Gcm>::from(*key)),
+		Nonce::<Aes256Gcm>::from(nonce),
+	))
+}
+
+/// Responder-side boot keypair. Opens sealed requests and seals responses.
+pub struct Responder {
+	domain: ChannelDomain,
+	secret_key: <Kem as KemTrait>::PrivateKey,
+	public_key: [u8; ENCRYPTION_KEY_LEN],
+}
+
+impl Responder {
+	/// Generates a fresh keypair from `rng`, serving `domain`.
+	///
+	/// # Panics
+	///
+	/// Panics if the KEM produces a public key that is not [`ENCRYPTION_KEY_LEN`] bytes.
+	#[must_use]
+	pub fn generate(domain: ChannelDomain, rng: &mut impl CryptoRng) -> Self {
+		let (secret_key, public_key) = Kem::gen_keypair_with_rng(rng);
+		let public_key = public_key
+			.to_bytes()
+			.as_slice()
+			.try_into()
+			.expect("X25519 public keys are 32 bytes");
+
+		Self {
+			domain,
+			secret_key,
+			public_key,
+		}
+	}
+
+	/// Returns the public key requesters seal to for this boot.
+	#[must_use]
+	pub const fn public_key(&self) -> [u8; ENCRYPTION_KEY_LEN] {
+		self.public_key
+	}
+
+	/// Returns the domain this responder serves.
+	#[must_use]
+	pub const fn domain(&self) -> ChannelDomain {
+		self.domain
+	}
+
+	/// Opens a sealed request and returns the plaintext plus a [`ResponseSealer`] for the reply.
+	///
+	/// # Errors
+	///
+	/// Returns [`ChannelError`] if the request is too short, the encapsulated key is unusable, the
+	/// ciphertext fails authentication, or the response secret cannot be exported.
+	pub fn open(
+		&self,
+		request: &SealedRequest,
+	) -> Result<(Zeroizing<Vec<u8>>, ResponseSealer), ChannelError> {
+		let body = request.as_ref();
+		if body.len() <= ENCAPSULATED_KEY_LEN + AEAD_TAG_LEN {
+			return Err(ChannelError::Truncated);
+		}
+		let (encapsulated, ciphertext) = body.split_at(ENCAPSULATED_KEY_LEN);
+		let encapsulated_key: [u8; ENCAPSULATED_KEY_LEN] = encapsulated
+			.try_into()
+			.map_err(|_| ChannelError::Truncated)?;
+
+		let encapped = <Kem as KemTrait>::EncappedKey::from_bytes(encapsulated)
+			.map_err(|_| ChannelError::InvalidEncapsulatedKey)?;
+
+		let info = self.domain.info(&self.public_key);
+		let mut context = setup_receiver::<ChannelAead, Kdf, Kem>(
+			&OpModeR::Base,
+			&self.secret_key,
+			&encapped,
+			&info,
+		)
+		.map_err(|_| ChannelError::InvalidEncapsulatedKey)?;
+
+		let plaintext = context
+			.open(ciphertext, &[])
+			.map_err(|_| ChannelError::OpenFailed)?;
+
+		let mut secret = Zeroizing::new([0u8; RESPONSE_NONCE_LEN]);
+		context
+			.export(&self.domain.exporter_label(), secret.as_mut_slice())
+			.map_err(|_| ChannelError::ExportFailed)?;
+
+		Ok((
+			Zeroizing::new(plaintext),
+			ResponseSealer {
+				secret,
+				encapsulated_key,
+			},
+		))
+	}
+}
+
+/// Requester-side handle built from a verified encryption public key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Requester {
+	domain: ChannelDomain,
+	public_key: [u8; ENCRYPTION_KEY_LEN],
+}
+
+impl Requester {
+	/// Builds a requester from an attested encryption public key.
+	///
+	/// This is a format check, not point validation: every 32-byte string decodes as an X25519
+	/// public key (RFC 7748 clamps on use), so a key yielding no valid shared secret — the
+	/// all-zero point, for instance — is only rejected when [`Self::seal`] runs encapsulation.
+	///
+	/// # Errors
+	///
+	/// Returns [`ChannelError::InvalidEncryptionKey`] if `public_key` cannot be decoded.
+	pub fn new(
+		domain: ChannelDomain,
+		public_key: [u8; ENCRYPTION_KEY_LEN],
+	) -> Result<Self, ChannelError> {
+		<Kem as KemTrait>::PublicKey::from_bytes(&public_key)
+			.map_err(|_| ChannelError::InvalidEncryptionKey)?;
+		Ok(Self { domain, public_key })
+	}
+
+	/// Builds a requester from the public key an attestation document carried.
+	///
+	/// # Errors
+	///
+	/// Returns [`ChannelError::InvalidEncryptionKey`] if `public_key` is not exactly
+	/// [`ENCRYPTION_KEY_LEN`] bytes or cannot be decoded; see [`Self::new`] for what decoding
+	/// does and does not validate.
+	pub fn from_attestation(
+		domain: ChannelDomain,
+		public_key: &[u8],
+	) -> Result<Self, ChannelError> {
+		let public_key: [u8; ENCRYPTION_KEY_LEN] = public_key
+			.try_into()
+			.map_err(|_| ChannelError::InvalidEncryptionKey)?;
+		Self::new(domain, public_key)
+	}
+
+	/// Returns the raw X25519 public key.
+	#[must_use]
+	pub const fn public_key(&self) -> [u8; ENCRYPTION_KEY_LEN] {
+		self.public_key
+	}
+
+	/// Returns the domain this requester seals under.
+	#[must_use]
+	pub const fn domain(&self) -> ChannelDomain {
+		self.domain
+	}
+
+	/// Seals one request, returning the wire body and a [`ResponseOpener`] for the reply.
+	///
+	/// # Errors
+	///
+	/// Returns [`ChannelError`] if the public key yields no shared secret, or the AEAD refuses to
+	/// seal.
+	pub fn seal(
+		&self,
+		plaintext: &[u8],
+		rng: &mut impl CryptoRng,
+	) -> Result<(SealedRequest, ResponseOpener), ChannelError> {
+		let public_key = <Kem as KemTrait>::PublicKey::from_bytes(&self.public_key)
+			.map_err(|_| ChannelError::InvalidEncryptionKey)?;
+
+		let info = self.domain.info(&self.public_key);
+		let (encapped, mut context) =
+			setup_sender_with_rng::<ChannelAead, Kdf, Kem>(&OpModeS::Base, &public_key, &info, rng)
+				.map_err(|_| ChannelError::InvalidEncryptionKey)?;
+
+		let ciphertext = context
+			.seal(plaintext, &[])
+			.map_err(|_| ChannelError::SealFailed)?;
+
+		let encapsulated = encapped.to_bytes();
+		let encapsulated_key: [u8; ENCAPSULATED_KEY_LEN] = encapsulated
+			.as_slice()
+			.try_into()
+			.map_err(|_| ChannelError::InvalidEncapsulatedKey)?;
+
+		let mut body = encapsulated_key.to_vec();
+		body.extend_from_slice(&ciphertext);
+
+		Ok((
+			SealedRequest(body),
+			ResponseOpener {
+				exporter_label: self.domain.exporter_label(),
+				context,
+				encapsulated_key,
+			},
+		))
+	}
+}
+
+/// Opens the response belonging to one [`Requester::seal`] call.
+pub struct ResponseOpener {
+	exporter_label: Vec<u8>,
+	context: AeadCtxS<ChannelAead, Kdf, Kem>,
+	encapsulated_key: [u8; ENCAPSULATED_KEY_LEN],
+}
+
+impl ResponseOpener {
+	/// Opens a sealed response.
+	///
+	/// # Errors
+	///
+	/// Returns [`ChannelError`] if the response is too short, the secret cannot be exported or
+	/// expanded, or the ciphertext fails authentication.
+	pub fn open(&self, response: &SealedResponse) -> Result<Zeroizing<Vec<u8>>, ChannelError> {
+		let sealed = response.as_ref();
+		if sealed.len() <= RESPONSE_NONCE_LEN + AEAD_TAG_LEN {
+			return Err(ChannelError::Truncated);
+		}
+		let (response_nonce, ciphertext) = sealed.split_at(RESPONSE_NONCE_LEN);
+		let response_nonce: [u8; RESPONSE_NONCE_LEN] = response_nonce
+			.try_into()
+			.map_err(|_| ChannelError::Truncated)?;
+
+		let mut secret = Zeroizing::new([0u8; RESPONSE_NONCE_LEN]);
+		self.context
+			.export(&self.exporter_label, secret.as_mut_slice())
+			.map_err(|_| ChannelError::ExportFailed)?;
+
+		let (cipher, nonce) =
+			derive_response_aead(&secret, &self.encapsulated_key, &response_nonce)?;
+
+		let plaintext = cipher
+			.decrypt(&nonce, ciphertext)
+			.map_err(|_| ChannelError::OpenFailed)?;
+
+		Ok(Zeroizing::new(plaintext))
+	}
+}
+
+/// Seals the one response belonging to a [`Responder::open`] call.
+pub struct ResponseSealer {
+	secret: ResponseSecret,
+	encapsulated_key: [u8; ENCAPSULATED_KEY_LEN],
+}
+
+impl ResponseSealer {
+	/// Seals one response, per RFC 9458 §4.4.
+	///
+	/// # Errors
+	///
+	/// Returns [`ChannelError`] if the key or nonce cannot be expanded, or the AEAD refuses to
+	/// seal.
+	pub fn seal(
+		self,
+		plaintext: &[u8],
+		rng: &mut impl CryptoRng,
+	) -> Result<SealedResponse, ChannelError> {
+		let mut response_nonce = [0u8; RESPONSE_NONCE_LEN];
+		rng.fill_bytes(&mut response_nonce);
+
+		let (cipher, nonce) =
+			derive_response_aead(&self.secret, &self.encapsulated_key, &response_nonce)?;
+
+		let ciphertext = cipher
+			.encrypt(&nonce, plaintext)
+			.map_err(|_| ChannelError::SealFailed)?;
+
+		let mut sealed = response_nonce.to_vec();
+		sealed.extend_from_slice(&ciphertext);
+
+		Ok(SealedResponse(sealed))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use getrandom::SysRng;
+	use hpke::rand_core::UnwrapErr;
+
+	use super::{
+		AEAD_TAG_LEN, ChannelDomain, ChannelError, ENCAPSULATED_KEY_LEN, EXPORTER_LABEL_SUFFIX,
+		RESPONSE_NONCE_LEN, Requester, Responder, ResponseOpener, SealedRequest, SealedResponse,
+	};
+
+	const TEST_DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/test", 1);
+
+	fn seal_to(responder: &Responder, plaintext: &[u8]) -> (SealedRequest, ResponseOpener) {
+		let requester =
+			Requester::new(responder.domain(), responder.public_key()).expect("valid key");
+		let mut rng = UnwrapErr(SysRng);
+		let (request, opener) = requester
+			.seal(plaintext, &mut rng)
+			.expect("sealing should succeed");
+		(request, opener)
+	}
+
+	fn test_rng() -> UnwrapErr<SysRng> {
+		UnwrapErr(SysRng)
+	}
+
+	#[test]
+	fn requester_from_attestation_matches_new() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let from_attestation = Requester::from_attestation(TEST_DOMAIN, &responder.public_key())
+			.expect("should parse");
+		let from_new = Requester::new(TEST_DOMAIN, responder.public_key()).expect("should parse");
+		assert_eq!(from_attestation, from_new);
+	}
+
+	#[test]
+	fn rejects_a_non_32_byte_attestation_key() {
+		assert_eq!(
+			Requester::from_attestation(TEST_DOMAIN, &[0u8; 31]).err(),
+			Some(ChannelError::InvalidEncryptionKey)
+		);
+	}
+
+	#[test]
+	fn info_binds_name_version_and_key() {
+		let key = [7u8; 32];
+		let info = TEST_DOMAIN.info(&key);
+		let (name, rest) = info.split_at(TEST_DOMAIN.name().len());
+		assert_eq!(name, TEST_DOMAIN.name().as_bytes());
+		assert_eq!(rest, [&[TEST_DOMAIN.version()][..], &key[..]].concat());
+	}
+
+	#[test]
+	fn info_separates_names_versions_and_keys() {
+		let key = [7u8; 32];
+		let other_name = ChannelDomain::new("pontifex/other", TEST_DOMAIN.version());
+		let next_version = ChannelDomain::new(TEST_DOMAIN.name(), TEST_DOMAIN.version() + 1);
+
+		assert_ne!(TEST_DOMAIN.info(&key), other_name.info(&key));
+		assert_ne!(TEST_DOMAIN.info(&key), next_version.info(&key));
+		assert_ne!(TEST_DOMAIN.info(&key), TEST_DOMAIN.info(&[8u8; 32]));
+	}
+
+	#[test]
+	fn exporter_label_follows_the_name() {
+		assert_eq!(
+			TEST_DOMAIN.exporter_label(),
+			[TEST_DOMAIN.name().as_bytes(), EXPORTER_LABEL_SUFFIX].concat()
+		);
+		assert_ne!(
+			TEST_DOMAIN.exporter_label(),
+			ChannelDomain::new("pontifex/other", 1).exporter_label()
+		);
+	}
+
+	#[test]
+	fn separate_responders_receive_separate_public_keys() {
+		assert_ne!(
+			Responder::generate(TEST_DOMAIN, &mut test_rng()).public_key(),
+			Responder::generate(TEST_DOMAIN, &mut test_rng()).public_key()
+		);
+	}
+
+	#[test]
+	fn public_key_is_stable_for_one_responder() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		assert_eq!(responder.public_key(), responder.public_key());
+	}
+
+	#[test]
+	fn round_trips_a_request_and_its_sealed_response() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, opener) = seal_to(&responder, b"request inputs");
+
+		let (plaintext, sealer) = responder.open(&request).expect("should open");
+		assert_eq!(&plaintext[..], b"request inputs");
+
+		let response = sealer
+			.seal(b"statement", &mut test_rng())
+			.expect("sealing should succeed");
+
+		assert_eq!(&*opener.open(&response).unwrap(), b"statement".as_ref());
+	}
+
+	#[test]
+	fn each_response_draws_a_fresh_nonce() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, opener) = seal_to(&responder, b"request inputs");
+
+		let (_, first_sealer) = responder.open(&request).expect("should open");
+		let (_, second_sealer) = responder.open(&request).expect("should open");
+		let first = first_sealer
+			.seal(b"statement", &mut test_rng())
+			.expect("should seal");
+		let second = second_sealer
+			.seal(b"statement", &mut test_rng())
+			.expect("should seal");
+
+		assert_ne!(
+			first.as_ref()[..RESPONSE_NONCE_LEN],
+			second.as_ref()[..RESPONSE_NONCE_LEN],
+		);
+		assert_ne!(
+			first.as_ref()[RESPONSE_NONCE_LEN..],
+			second.as_ref()[RESPONSE_NONCE_LEN..],
+		);
+		assert_eq!(&*opener.open(&first).unwrap(), b"statement".as_ref());
+		assert_eq!(&*opener.open(&second).unwrap(), b"statement".as_ref());
+	}
+
+	#[test]
+	fn rejects_a_request_sealed_to_another_boot() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let other = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, _) = seal_to(&other, b"request inputs");
+
+		assert_eq!(
+			responder.open(&request).err(),
+			Some(ChannelError::OpenFailed)
+		);
+	}
+
+	#[test]
+	fn rejects_a_request_bound_to_another_channel_version() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let next_version = ChannelDomain::new(TEST_DOMAIN.name(), TEST_DOMAIN.version() + 1);
+		let requester = Requester::new(next_version, responder.public_key()).expect("valid key");
+		let (request, _) = requester
+			.seal(b"request inputs", &mut test_rng())
+			.expect("sealing should succeed");
+
+		assert_eq!(
+			responder.open(&request).err(),
+			Some(ChannelError::OpenFailed)
+		);
+	}
+
+	#[test]
+	fn rejects_a_request_sealed_under_another_domain_name() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let other_name = ChannelDomain::new("pontifex/other", TEST_DOMAIN.version());
+		let requester = Requester::new(other_name, responder.public_key()).expect("valid key");
+		let (request, _) = requester
+			.seal(b"request inputs", &mut test_rng())
+			.expect("sealing should succeed");
+
+		assert_eq!(
+			responder.open(&request).err(),
+			Some(ChannelError::OpenFailed)
+		);
+	}
+
+	#[test]
+	fn rejects_a_low_order_encapsulated_key() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, _) = seal_to(&responder, b"request inputs");
+		let mut body = request.into_bytes();
+		body[..ENCAPSULATED_KEY_LEN].fill(0);
+
+		assert_eq!(
+			responder.open(&SealedRequest(body)).err(),
+			Some(ChannelError::InvalidEncapsulatedKey)
+		);
+	}
+
+	#[test]
+	fn rejects_a_truncated_request_body() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+
+		for length in [0, ENCAPSULATED_KEY_LEN, ENCAPSULATED_KEY_LEN + AEAD_TAG_LEN] {
+			assert_eq!(
+				responder
+					.open(&SealedRequest::from_bytes(vec![0u8; length]))
+					.err(),
+				Some(ChannelError::Truncated),
+				"length {length}"
+			);
+		}
+	}
+
+	#[test]
+	fn rejects_a_tampered_request_ciphertext() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, _) = seal_to(&responder, b"request inputs");
+		let mut body = request.into_bytes();
+		body[ENCAPSULATED_KEY_LEN] ^= 0x01;
+
+		assert_eq!(
+			responder.open(&SealedRequest(body)).err(),
+			Some(ChannelError::OpenFailed)
+		);
+	}
+
+	#[test]
+	fn rejects_a_truncated_response() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+
+		for length in [0, RESPONSE_NONCE_LEN, RESPONSE_NONCE_LEN + AEAD_TAG_LEN] {
+			let (_, opener) = seal_to(&responder, b"request inputs");
+			assert_eq!(
+				opener
+					.open(&SealedResponse::from_bytes(vec![0u8; length]))
+					.err(),
+				Some(ChannelError::Truncated),
+				"length {length}"
+			);
+		}
+	}
+
+	#[test]
+	fn a_second_request_to_the_same_key_cannot_open_the_response() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, _) = seal_to(&responder, b"request inputs");
+		let (_, eavesdropper) = seal_to(&responder, b"unrelated");
+
+		let (_, sealer) = responder.open(&request).expect("should open");
+		let response = sealer
+			.seal(b"statement", &mut test_rng())
+			.expect("sealing should succeed");
+
+		assert_eq!(
+			eavesdropper.open(&response).err(),
+			Some(ChannelError::OpenFailed)
+		);
+	}
+
+	#[test]
+	fn rejects_a_tampered_response_ciphertext() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, opener) = seal_to(&responder, b"request inputs");
+		let (_, sealer) = responder.open(&request).expect("should open");
+
+		let response = sealer
+			.seal(b"statement", &mut test_rng())
+			.expect("sealing should succeed");
+		let mut body = response.into_bytes();
+		body[RESPONSE_NONCE_LEN] ^= 0x01;
+
+		assert_eq!(
+			opener.open(&SealedResponse(body)).err(),
+			Some(ChannelError::OpenFailed)
+		);
+	}
+
+	#[test]
+	fn rejects_a_tampered_response_nonce() {
+		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
+		let (request, opener) = seal_to(&responder, b"request inputs");
+		let (_, sealer) = responder.open(&request).expect("should open");
+
+		let response = sealer
+			.seal(b"statement", &mut test_rng())
+			.expect("sealing should succeed");
+		let mut body = response.into_bytes();
+		body[0] ^= 0x01;
+
+		assert_eq!(
+			opener.open(&SealedResponse(body)).err(),
+			Some(ChannelError::OpenFailed)
+		);
+	}
+
+	#[test]
+	fn rejects_an_invalid_encryption_key() {
+		// All-zero encodes as a point but yields no valid shared secret at encapsulation.
+		let requester = Requester::new(TEST_DOMAIN, [0u8; 32]).expect("all-zero key encodes");
+		let result = requester.seal(b"request inputs", &mut test_rng());
+
+		assert_eq!(result.err(), Some(ChannelError::InvalidEncryptionKey));
+	}
+}
+
+/// Known-answer tests.
+///
+/// Three layers, each guarding a different failure mode:
+///
+/// 1. **Official RFC 9180 vector** for this module's exact suite — `mode_base`,
+///    DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-256-GCM — taken from the reference vector set
+///    the `hpke` crate ships (`test-vectors/origrfc-5f503c5.json`; the RFC's own appendix has no
+///    vector for this AEAD with X25519). Catches a broken build of the suite itself: upstream's
+///    vector tests never run in this repository's CI.
+/// 2. **Independent HKDF vector** for the response derivation, computed with a stdlib-only
+///    Python HMAC implementation that shares no code with the `hkdf` crate. Pins the
+///    `enc || response_nonce` salt construction and the `"key"`/`"nonce"` labels.
+/// 3. **Deterministic wire vectors** for the full channel under a fixed RNG. Self-generated, so
+///    they verify nothing about correctness — they freeze the wire contract (the `info`
+///    construction, the exporter label, the suite, framing) so any accidental change fails a
+///    test instead of shipping silently.
+#[cfg(test)]
+mod kat {
+	use core::convert::Infallible;
+
+	use hex_literal::hex;
+	use hpke::rand_core::{TryCryptoRng, TryRng};
+
+	use super::*;
+
+	/// Yields exactly the queued bytes, in order. Panics when drained, so a test that consumes
+	/// more randomness than its vector provides fails loudly instead of diverging silently.
+	struct FixedRng(Vec<u8>);
+
+	impl FixedRng {
+		fn new(bytes: &[u8]) -> Self {
+			Self(bytes.to_vec())
+		}
+	}
+
+	impl TryRng for FixedRng {
+		type Error = Infallible;
+
+		fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+			let mut bytes = [0u8; 4];
+			self.try_fill_bytes(&mut bytes)?;
+			Ok(u32::from_le_bytes(bytes))
+		}
+
+		fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+			let mut bytes = [0u8; 8];
+			self.try_fill_bytes(&mut bytes)?;
+			Ok(u64::from_le_bytes(bytes))
+		}
+
+		fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+			assert!(
+				self.0.len() >= dst.len(),
+				"FixedRng drained: the test consumed more randomness than its vector provides"
+			);
+			let rest = self.0.split_off(dst.len());
+			dst.copy_from_slice(&self.0);
+			self.0 = rest;
+			Ok(())
+		}
+	}
+
+	impl TryCryptoRng for FixedRng {}
+
+	// RFC 9180 reference vector: mode_base, kem_id 0x0020, kdf_id 0x0001, aead_id 0x0002.
+	// Source: the `hpke` crate's `test-vectors/origrfc-5f503c5.json`.
+	const IKM_E: [u8; 32] =
+		hex!("2cd7c601cefb3d42a62b04b7a9041494c06c7843818e0ce28a8f704ae7ab20f9");
+	const IKM_R: [u8; 32] =
+		hex!("dac33b0e9db1b59dbbea58d59a14e7b5896e9bdf98fad6891e99d1686492b9ee");
+	const PK_RM: [u8; 32] =
+		hex!("430f4b9859665145a6b1ba274024487bd66f03a2dd577d7753c68d7d7d00c00c");
+	const ENC: [u8; 32] = hex!("6c93e09869df3402d7bf231bf540fadd35cd56be14f97178f0954db94b7fc256");
+	/// "Ode on a Grecian Urn"
+	const VECTOR_INFO: &[u8] = &hex!("4f6465206f6e2061204772656369616e2055726e");
+	/// "Beauty is truth, truth beauty"
+	const VECTOR_PT: &[u8] = &hex!("4265617574792069732074727574682c20747275746820626561757479");
+	/// "Count-0"
+	const VECTOR_AAD: &[u8] = &hex!("436f756e742d30");
+	const VECTOR_CT: &[u8] = &hex!(
+		"e5d84cd531cfb583096e7cfa9641bd3079cf3a91cda813c52deb5f512be9931980a41de125a925cdad859d5b7a"
+	);
+	const EXPORT_EMPTY_CONTEXT: [u8; 32] =
+		hex!("ded6cffafaea6b812cbf3e241e88332adbc077aca81512914213810ee291770a");
+	const EXPORT_TEST_CONTEXT: [u8; 32] =
+		hex!("7c5ded445732c14fe09727d29b4251c0fd38455fe8440571e687f0886aac94d2");
+
+	/// Layer 1: the `hpke` crate, built with this crate's feature set, reproduces the official
+	/// vector for the exact suite this module pins.
+	///
+	/// The ephemeral is reproducible because DHKEM's `encap_with_rng` is
+	/// `DeriveKeyPair(random(Nsk))`: feeding the RNG the vector's `ikmE` yields the vector's
+	/// ephemeral key.
+	#[test]
+	fn hpke_suite_matches_the_official_vector() {
+		// Recipient keypair from ikmR.
+		let (sk_r, pk_r) = <Kem as KemTrait>::derive_keypair(&IKM_R);
+		assert_eq!(pk_r.to_bytes().as_slice(), PK_RM, "pkRm");
+
+		// Sender: ephemeral from ikmE, then seal the vector's first plaintext.
+		let pk_recip = <Kem as KemTrait>::PublicKey::from_bytes(&PK_RM).expect("pkRm decodes");
+		let mut rng = FixedRng::new(&IKM_E);
+		let (encapped, mut sender) = setup_sender_with_rng::<ChannelAead, Kdf, Kem>(
+			&OpModeS::Base,
+			&pk_recip,
+			VECTOR_INFO,
+			&mut rng,
+		)
+		.expect("sender setup");
+		assert_eq!(encapped.to_bytes().as_slice(), ENC, "enc");
+		let ciphertext = sender.seal(VECTOR_PT, VECTOR_AAD).expect("seal");
+		assert_eq!(ciphertext.as_slice(), VECTOR_CT, "ct[0]");
+
+		// Receiver: open the vector ciphertext.
+		let encapped = <Kem as KemTrait>::EncappedKey::from_bytes(&ENC).expect("enc decodes");
+		let mut receiver =
+			setup_receiver::<ChannelAead, Kdf, Kem>(&OpModeR::Base, &sk_r, &encapped, VECTOR_INFO)
+				.expect("receiver setup");
+		assert_eq!(
+			receiver
+				.open(VECTOR_CT, VECTOR_AAD)
+				.expect("open")
+				.as_slice(),
+			VECTOR_PT,
+			"pt[0]"
+		);
+
+		// Exporter, both sides.
+		let mut exported = [0u8; 32];
+		receiver.export(b"", &mut exported).expect("export");
+		assert_eq!(exported, EXPORT_EMPTY_CONTEXT, "export(\"\")");
+		sender
+			.export(b"TestContext", &mut exported)
+			.expect("export");
+		assert_eq!(exported, EXPORT_TEST_CONTEXT, "export(\"TestContext\")");
+	}
+
+	/// Layer 2: the response `Extract`/`Expand` chain matches a vector computed with a
+	/// stdlib-only Python HMAC implementation — independent of the `hkdf` crate.
+	///
+	/// ```text
+	/// prk   = HMAC-SHA256(salt = enc || response_nonce, ikm = secret)
+	/// key   = HKDF-Expand(prk, "key", 32)
+	/// nonce = HKDF-Expand(prk, "nonce", 12)
+	/// ```
+	#[test]
+	fn response_derivation_matches_an_independent_hkdf() {
+		let secret: ResponseSecret =
+			Zeroizing::new(core::array::from_fn(|i| u8::try_from(i).unwrap()));
+		let encapsulated_key: [u8; ENCAPSULATED_KEY_LEN] =
+			core::array::from_fn(|i| u8::try_from(0x20 + i).unwrap());
+		let response_nonce: [u8; RESPONSE_NONCE_LEN] =
+			core::array::from_fn(|i| u8::try_from(0x40 + i).unwrap());
+
+		let (key, nonce) = derive_response_key_nonce(&secret, &encapsulated_key, &response_nonce)
+			.expect("derivation");
+
+		assert_eq!(
+			*key,
+			hex!("40ec528847cd4e928449f2ed1a70a7d1e8ee317d5e900424fc1dd5b0475b97f7")
+		);
+		assert_eq!(nonce, hex!("f8b0ce9466f27aa6243c65f9"));
+	}
+
+	/// The domain the pinned vectors below were generated under, before this module moved into
+	/// pontifex. Kept verbatim so the frozen bytes stay comparable across the move: the same
+	/// inputs still produce the same wire, which is what makes them a regression test rather
+	/// than a re-baseline.
+	const PINNED_DOMAIN: ChannelDomain = ChannelDomain::new("embedding-verifier/match", 1);
+
+	/// Layer 3 (regression, self-generated): the full channel under a fixed RNG produces these
+	/// exact wire bytes. Freezes the `info` construction, the exporter label, the suite, and
+	/// framing — any of them changing alters the bytes and fails this test, which is the point:
+	/// the wire contract only moves together with the domain's version.
+	#[test]
+	fn wire_bytes_are_frozen_under_a_fixed_rng() {
+		let responder = Responder::generate(PINNED_DOMAIN, &mut FixedRng::new(&[0x11; 32]));
+		assert_eq!(responder.public_key(), PINNED_PUBLIC_KEY, "responder key");
+
+		let requester = Requester::new(PINNED_DOMAIN, responder.public_key()).expect("valid key");
+		let (request, opener) = requester
+			.seal(b"match inputs", &mut FixedRng::new(&[0x22; 32]))
+			.expect("seal");
+		assert_eq!(request.as_ref(), PINNED_REQUEST, "request bytes");
+
+		let (plaintext, sealer) = responder
+			.open(&SealedRequest::from_bytes(PINNED_REQUEST.to_vec()))
+			.expect("open");
+		assert_eq!(&plaintext[..], b"match inputs");
+
+		let response = sealer
+			.seal(b"statement", &mut FixedRng::new(&[0x33; 32]))
+			.expect("seal response");
+		assert_eq!(response.as_ref(), PINNED_RESPONSE, "response bytes");
+
+		assert_eq!(
+			&*opener
+				.open(&SealedResponse::from_bytes(PINNED_RESPONSE.to_vec()))
+				.expect("open response"),
+			b"statement".as_ref()
+		);
+	}
+
+	const PINNED_PUBLIC_KEY: [u8; 32] =
+		hex!("1a239249ea74403babc01f32df9931a16f71ac8972c461d69fed15640e310639");
+	const PINNED_REQUEST: [u8; 60] = hex!(
+		"e3b9708aaa21a7f1e62a95ee28d1e5d60b0fceed6c68599013a54b318e9e0b15"
+		"81fd0d3318729a9833bb0a090f9af62d8b87fc166aee22d70849f970"
+	);
+	const PINNED_RESPONSE: [u8; 57] = hex!(
+		// The leading 32 bytes are the response_nonce exactly as drawn from the fixed RNG,
+		// confirming the `response_nonce || ciphertext` layout of RFC 9458 section 4.4 step 7.
+		"3333333333333333333333333333333333333333333333333333333333333333"
+		"ede83b5b125ab339ee2bd91d320571a796feec732954644a95"
+	);
+}

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -25,20 +25,16 @@
 //! substitution the RFC directs rather than a deviation from it.
 
 use aes_gcm::{
-	Aes256Gcm, Key, KeyInit,
 	aead::{Aead, Nonce},
+	Aes256Gcm, Key, KeyInit,
 };
 use channel_sha2::Sha256;
 use hkdf::Hkdf;
 use hpke::{
-	Deserializable, Kem as KemTrait, OpModeR, OpModeS, Serializable, aead::AeadCtxS,
-	rand_core::CryptoRng, setup_receiver, setup_sender_with_rng,
+	aead::AeadCtxS, rand_core::CryptoRng, setup_receiver, setup_sender_with_rng, Deserializable,
+	Kem as KemTrait, OpModeR, OpModeS, Serializable,
 };
 use zeroize::Zeroizing;
-
-/// Re-exported so callers bind against the same `rand_core` generation this crate does.
-pub use hpke::rand_core;
-pub use hpke::rand_core::UnwrapErr;
 
 /// The channel ciphersuite, pinned at the type level so it cannot drift silently:
 /// DHKEM(X25519, HKDF-SHA256) — RFC 9180 §7.1.
@@ -513,8 +509,9 @@ mod tests {
 	use hpke::rand_core::UnwrapErr;
 
 	use super::{
-		AEAD_TAG_LEN, ChannelDomain, ChannelError, ENCAPSULATED_KEY_LEN, EXPORTER_LABEL_SUFFIX,
-		RESPONSE_NONCE_LEN, Requester, Responder, ResponseOpener, SealedRequest, SealedResponse,
+		ChannelDomain, ChannelError, Requester, Responder, ResponseOpener, SealedRequest,
+		SealedResponse, AEAD_TAG_LEN, ENCAPSULATED_KEY_LEN, EXPORTER_LABEL_SUFFIX,
+		RESPONSE_NONCE_LEN,
 	};
 
 	const TEST_DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/test", 1);

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -12,10 +12,8 @@
 //!
 //! # Domain separation
 //!
-//! Every channel is opened under a [`ChannelDomain`], which the caller owns: a protocol name and
-//! a wire version. Both are bound into the HPKE `info`, and the name also derives the response
-//! exporter label, so two protocols sharing one enclave keypair cannot open each other's
-//! messages and a version bump fails at channel setup rather than as a misparse.
+//! Channels are opened under a caller-named [`ChannelDomain`] bound into the HPKE `info`, so
+//! neither another protocol nor another wire version can open a channel's messages.
 //!
 //! # Relationship to RFC 9458 §4.4
 //!
@@ -38,8 +36,7 @@ use hpke::{
 };
 use zeroize::Zeroizing;
 
-/// The RNG traits the channel seals and generates against, re-exported so callers bind against
-/// the same generation this crate does.
+/// Re-exported so callers bind against the same `rand_core` generation this crate does.
 pub use hpke::rand_core;
 pub use hpke::rand_core::UnwrapErr;
 
@@ -54,7 +51,7 @@ type ChannelAead = hpke::aead::AesGcm256;
 /// Length of an X25519 public key, which is what an enclave attests.
 pub const ENCRYPTION_KEY_LEN: usize = 32;
 
-/// Suffix appended to a [`ChannelDomain`]'s name to form the response exporter label.
+/// Appended to a domain name to form the response exporter label.
 const EXPORTER_LABEL_SUFFIX: &[u8] = b" response";
 
 /// `Expand` info for the response AEAD key — RFC 9458 §4.4 step 4.
@@ -106,14 +103,11 @@ pub enum ChannelError {
 	SealFailed,
 }
 
-/// What a channel is opened for: a protocol name and the version of its wire contract.
+/// A protocol name and the version of its wire contract, both bound into the HPKE `info`.
 ///
-/// The name is the caller's domain-separation string — pick one that identifies the protocol,
-/// not the crate, and never reuse it across protocols. Both fields are bound into the HPKE
-/// `info`, and the name derives the RFC 9458 §4.4 exporter label as `"<name> response"`.
-///
-/// Bumping [`version`](Self::version) makes every channel under the old number fail at setup, so
-/// it is the lever for a breaking change to whatever the sealed bytes mean.
+/// Name one protocol per domain and never reuse it; the name also derives the RFC 9458 §4.4
+/// exporter label as `"<name> response"`. Bumping the version fails every channel under the old
+/// number at setup, which is the lever for a breaking change to the sealed bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ChannelDomain {
 	name: &'static str,
@@ -133,7 +127,7 @@ impl ChannelDomain {
 		self.name
 	}
 
-	/// Returns the wire version bound into every channel under this domain.
+	/// Returns the wire version.
 	#[must_use]
 	pub const fn version(&self) -> u8 {
 		self.version
@@ -969,11 +963,7 @@ mod kat {
 		assert_eq!(nonce, hex!("f8b0ce9466f27aa6243c65f9"));
 	}
 
-	/// The domain the pinned vectors below were generated under, before this module moved into
-	/// pontifex. Kept verbatim so the frozen bytes stay comparable across the move: the same
-	/// inputs still produce the same wire, which is what makes them a regression test rather
-	/// than a re-baseline.
-	const PINNED_DOMAIN: ChannelDomain = ChannelDomain::new("embedding-verifier/match", 1);
+	const PINNED_DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/kat", 1);
 
 	/// Layer 3 (regression, self-generated): the full channel under a fixed RNG produces these
 	/// exact wire bytes. Freezes the `info` construction, the exporter label, the suite, and
@@ -986,17 +976,17 @@ mod kat {
 
 		let requester = Requester::new(PINNED_DOMAIN, responder.public_key()).expect("valid key");
 		let (request, opener) = requester
-			.seal(b"match inputs", &mut FixedRng::new(&[0x22; 32]))
+			.seal(b"request", &mut FixedRng::new(&[0x22; 32]))
 			.expect("seal");
 		assert_eq!(request.as_ref(), PINNED_REQUEST, "request bytes");
 
 		let (plaintext, sealer) = responder
 			.open(&SealedRequest::from_bytes(PINNED_REQUEST.to_vec()))
 			.expect("open");
-		assert_eq!(&plaintext[..], b"match inputs");
+		assert_eq!(&plaintext[..], b"request");
 
 		let response = sealer
-			.seal(b"statement", &mut FixedRng::new(&[0x33; 32]))
+			.seal(b"response", &mut FixedRng::new(&[0x33; 32]))
 			.expect("seal response");
 		assert_eq!(response.as_ref(), PINNED_RESPONSE, "response bytes");
 
@@ -1004,20 +994,20 @@ mod kat {
 			&*opener
 				.open(&SealedResponse::from_bytes(PINNED_RESPONSE.to_vec()))
 				.expect("open response"),
-			b"statement".as_ref()
+			b"response".as_ref()
 		);
 	}
 
 	const PINNED_PUBLIC_KEY: [u8; 32] =
 		hex!("1a239249ea74403babc01f32df9931a16f71ac8972c461d69fed15640e310639");
-	const PINNED_REQUEST: [u8; 60] = hex!(
+	const PINNED_REQUEST: [u8; 55] = hex!(
 		"e3b9708aaa21a7f1e62a95ee28d1e5d60b0fceed6c68599013a54b318e9e0b15"
-		"81fd0d3318729a9833bb0a090f9af62d8b87fc166aee22d70849f970"
+		"87b0e1436d37cefc7e16eaad8c44b8ed52167a1590ea1d"
 	);
-	const PINNED_RESPONSE: [u8; 57] = hex!(
+	const PINNED_RESPONSE: [u8; 56] = hex!(
 		// The leading 32 bytes are the response_nonce exactly as drawn from the fixed RNG,
 		// confirming the `response_nonce || ciphertext` layout of RFC 9458 section 4.4 step 7.
 		"3333333333333333333333333333333333333333333333333333333333333333"
-		"ede83b5b125ab339ee2bd91d320571a796feec732954644a95"
+		"2e6fd9ad62e341764bf330365541c95455743e6f683bda87"
 	);
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -13,6 +13,8 @@
 //!   could have encrypted a response to it with its public key. If the use case requires trusting
 //!   the enclave response, add an additional attestation or signature mechanism.
 //! 3. This module currently does **NOT** verify an attestation on the enclave's public key.
+//! 4. This system does not offer direct replay protection for requests (e.g. a malicious host could inject
+//!   the same ciphertext multiple times). Add a separate mechanism if your trust assumptions require this.
 
 use quantum_box::{PublicKey, SecretKey};
 use zeroize::ZeroizeOnDrop;
@@ -196,7 +198,7 @@ impl ChannelConsumer {
 	///
 	/// # Errors
 	///
-	/// Fails if the operating system CSPRNG is unavailable, or an unxpected seal error.
+	/// Fails if the operating system CSPRNG is unavailable, or sealing unexpectedly fails.
 	pub fn seal_to_enclave(
 		&self,
 		plaintext: &[u8],

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,109 +1,39 @@
 //! A confidential channel to a specific, measured enclave.
 //!
-//! Requests use [RFC 9180](https://datatracker.ietf.org/doc/rfc9180/) `mode_base` directly.
-//! Responses use the encapsulation construction of
-//! [RFC 9458 §4.4](https://datatracker.ietf.org/doc/rfc9458/) — Oblivious HTTP — because it
-//! solves exactly the problem a request-response enclave path has: replying to one HPKE request
-//! without a second key exchange, and without reusing the request context in reverse, which
-//! RFC 9180 §9.8 forbids.
+//! Every message is a [`quantum_box`] sealed box — an anonymous HPKE seal over the X-Wing hybrid
+//! KEM — so the untrusted parent instance forwarding the bytes never sees plaintext.
 //!
-//! Both halves live in one module so the tests exercise the same code the enclave and the client
-//! each run, rather than a test-only reimplementation of one side.
+//! The enclave generates a [`Responder`] per boot and attests its public key. A client verifies
+//! the attestation, builds a [`Requester`] from the attested key, and seals to it. Each request
+//! carries a fresh reply key that the enclave seals the one matching response to, so the response
+//! needs no second round trip and only that requester can open it.
 //!
-//! # Domain separation
-//!
-//! Channels are opened under a caller-named [`ChannelDomain`] bound into the HPKE `info`, so
-//! neither another protocol nor another wire version can open a channel's messages.
-//!
-//! # Relationship to RFC 9458 §4.4
-//!
-//! Followed as written. The one substitution is the caller's exporter label (see
-//! [`ChannelDomain`]) in place of `"message/bhttp response"`. §4.4 step 1 points at §4.6,
-//! *Repurposing the Encapsulation Format*, for alternative message formats, and §6.4, *Key
-//! Management*, adds that the label was chosen for symmetry only and that designers reusing the
-//! format should pick a different one for key diversity. No BHTTP is carried here, so this is a
-//! substitution the RFC directs rather than a deviation from it.
+//! Both sides must name the same [`ChannelDomain`], which is bound into every seal.
 
-use aes_gcm::{
-	aead::{Aead, Nonce},
-	Aes256Gcm, Key, KeyInit,
-};
-use channel_sha2::Sha256;
-use hkdf::Hkdf;
-use hpke::{
-	aead::AeadCtxS, rand_core::CryptoRng, setup_receiver, setup_sender_with_rng, Deserializable,
-	Kem as KemTrait, OpModeR, OpModeS, Serializable,
-};
-use zeroize::Zeroizing;
+use quantum_box::{PublicKey, SecretKey};
 
-/// The channel ciphersuite, pinned at the type level so it cannot drift silently:
-/// DHKEM(X25519, HKDF-SHA256) — RFC 9180 §7.1.
-type Kem = hpke::kem::X25519HkdfSha256;
-/// HKDF-SHA256 — RFC 9180 §7.2.
-type Kdf = hpke::kdf::HkdfSha256;
-/// AES-256-GCM — RFC 9180 §7.3, AEAD id `0x0002`.
-type ChannelAead = hpke::aead::AesGcm256;
+/// Length of an X-Wing encapsulation key: ML-KEM-768 (1184) plus X25519 (32).
+const REPLY_KEY_LEN: usize = 1216;
 
-/// Length of an X25519 public key, which is what an enclave attests.
-pub const ENCRYPTION_KEY_LEN: usize = 32;
-
-/// Appended to a domain name to form the response exporter label.
-const EXPORTER_LABEL_SUFFIX: &[u8] = b" response";
-
-/// `Expand` info for the response AEAD key — RFC 9458 §4.4 step 4.
-const INFO_KEY: &[u8] = b"key";
-
-/// `Expand` info for the response AEAD nonce — RFC 9458 §4.4 step 5.
-const INFO_NONCE: &[u8] = b"nonce";
-
-/// Length of an HPKE encapsulated key under DHKEM(X25519, HKDF-SHA256) — RFC 9180 §7.1.
-const ENCAPSULATED_KEY_LEN: usize = 32;
-
-/// AES-256-GCM key length — RFC 9180 §7.3 `Nk`.
-const AEAD_KEY_LEN: usize = 32;
-
-/// AES-256-GCM nonce length — RFC 9180 §7.3 `Nn`.
-const AEAD_NONCE_LEN: usize = 12;
-
-/// GCM authentication tag length — RFC 9180 §7.3 `Nt`.
-const AEAD_TAG_LEN: usize = 16;
-
-/// `max(Nn, Nk)`, the length RFC 9458 §4.4 uses for both the exported secret (step 1) and the
-/// `response_nonce` (step 2).
-const RESPONSE_NONCE_LEN: usize = if AEAD_NONCE_LEN > AEAD_KEY_LEN {
-	AEAD_NONCE_LEN
-} else {
-	AEAD_KEY_LEN
-};
-
-const _: () = assert!(RESPONSE_NONCE_LEN >= AEAD_KEY_LEN);
-const _: () = assert!(RESPONSE_NONCE_LEN >= AEAD_NONCE_LEN);
+// Bound into the `info` so one key is never used for both directions.
+const REQUEST: u8 = 0;
+const RESPONSE: u8 = 1;
 
 /// Why a channel operation did not complete.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ChannelError {
-	/// A wire body was too short to hold its framing, a tag, and any plaintext.
-	Truncated,
-	/// The encapsulated key was malformed, or yielded the all-zero shared secret that
-	/// RFC 9180 §7.1.4 requires the KEM to abort on.
-	InvalidEncapsulatedKey,
-	/// The advertised encryption public key was not a valid X25519 point.
-	InvalidEncryptionKey,
-	/// The ciphertext failed authentication under the derived key.
-	OpenFailed,
-	/// Exporting the response secret from the request context failed — RFC 9458 §4.4 step 1.
-	ExportFailed,
-	/// Deriving the response AEAD key or nonce failed — RFC 9458 §4.4 steps 3 to 5.
-	DeriveFailed,
-	/// The AEAD refused to seal, which a well-formed key and nonce make unreachable.
-	SealFailed,
+	/// The request opened, but was too short to carry a reply key.
+	#[error("ChannelError::MissingReplyKey")]
+	MissingReplyKey,
+	/// A key, a seal, or an unseal failed.
+	#[error("ChannelError::SealedBox: {0}")]
+	SealedBox(#[from] quantum_box::Error),
 }
 
-/// A protocol name and the version of its wire contract, both bound into the HPKE `info`.
+/// A protocol name and the version of its wire contract, both bound into every seal.
 ///
-/// Name one protocol per domain and never reuse it; the name also derives the RFC 9458 §4.4
-/// exporter label as `"<name> response"`. Bumping the version fails every channel under the old
-/// number at setup, which is the lever for a breaking change to the sealed bytes.
+/// Name one protocol per domain and never reuse it. Bumping the version fails every message
+/// sealed under the old number, which is the lever for a breaking change to the sealed bytes.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ChannelDomain {
 	name: &'static str,
@@ -117,322 +47,107 @@ impl ChannelDomain {
 		Self { name, version }
 	}
 
-	/// Returns the protocol name.
-	#[must_use]
-	pub const fn name(&self) -> &'static str {
-		self.name
-	}
-
-	/// Returns the wire version.
-	#[must_use]
-	pub const fn version(&self) -> u8 {
-		self.version
-	}
-
-	/// HPKE `info`: name, wire version, and responder public key.
-	///
-	/// Both sides bind this into the key schedule, so a mismatched domain, version or boot fails
-	/// at setup rather than decrypting garbage.
-	fn info(&self, encryption_public_key: &[u8; ENCRYPTION_KEY_LEN]) -> Vec<u8> {
-		let name = self.name.as_bytes();
-		let mut info = Vec::with_capacity(name.len() + 1 + encryption_public_key.len());
-		info.extend_from_slice(name);
+	fn info(&self, direction: u8) -> Vec<u8> {
+		let mut info = self.name.as_bytes().to_vec();
 		info.push(self.version);
-		info.extend_from_slice(encryption_public_key);
+		info.push(direction);
 		info
 	}
-
-	/// Exporter context for the response secret — RFC 9458 §4.4 step 1.
-	fn exporter_label(&self) -> Vec<u8> {
-		let name = self.name.as_bytes();
-		let mut label = Vec::with_capacity(name.len() + EXPORTER_LABEL_SUFFIX.len());
-		label.extend_from_slice(name);
-		label.extend_from_slice(EXPORTER_LABEL_SUFFIX);
-		label
-	}
 }
 
-/// A sealed request on the wire: `enc || ciphertext`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SealedRequest(Vec<u8>);
-
-impl SealedRequest {
-	/// Wraps request bytes. Validation happens in [`Responder::open`].
-	#[must_use]
-	pub fn from_bytes(bytes: impl Into<Vec<u8>>) -> Self {
-		Self(bytes.into())
-	}
-
-	/// Returns the raw wire bytes.
-	#[must_use]
-	pub fn into_bytes(self) -> Vec<u8> {
-		self.0
-	}
-}
-
-impl AsRef<[u8]> for SealedRequest {
-	fn as_ref(&self) -> &[u8] {
-		&self.0
-	}
-}
-
-/// A sealed response on the wire: `response_nonce || ciphertext`.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SealedResponse(Vec<u8>);
-
-impl SealedResponse {
-	/// Wraps response bytes. Validation happens in [`ResponseOpener::open`].
-	#[must_use]
-	pub fn from_bytes(bytes: impl Into<Vec<u8>>) -> Self {
-		Self(bytes.into())
-	}
-
-	/// Returns the raw wire bytes.
-	#[must_use]
-	pub fn into_bytes(self) -> Vec<u8> {
-		self.0
-	}
-}
-
-impl AsRef<[u8]> for SealedResponse {
-	fn as_ref(&self) -> &[u8] {
-		&self.0
-	}
-}
-
-type ResponseSecret = Zeroizing<[u8; RESPONSE_NONCE_LEN]>;
-
-/// The `Extract`/`Expand` chain of RFC 9458 §4.4 steps 3 to 5, returning raw key material.
-///
-/// Split from [`derive_response_aead`] so a known-answer test can pin the derived bytes against
-/// an independently computed vector; production code never sees the raw key outside this file.
-fn derive_response_key_nonce(
-	secret: &ResponseSecret,
-	encapsulated_key: &[u8; ENCAPSULATED_KEY_LEN],
-	response_nonce: &[u8; RESPONSE_NONCE_LEN],
-) -> Result<(Zeroizing<[u8; AEAD_KEY_LEN]>, [u8; AEAD_NONCE_LEN]), ChannelError> {
-	let mut salt = Vec::with_capacity(ENCAPSULATED_KEY_LEN + RESPONSE_NONCE_LEN);
-	salt.extend_from_slice(encapsulated_key);
-	salt.extend_from_slice(response_nonce);
-
-	let hkdf = Hkdf::<Sha256>::new(Some(&salt), secret.as_slice());
-
-	let mut key = Zeroizing::new([0u8; AEAD_KEY_LEN]);
-	let mut nonce = [0u8; AEAD_NONCE_LEN];
-	hkdf.expand(INFO_KEY, key.as_mut_slice())
-		.and_then(|()| hkdf.expand(INFO_NONCE, &mut nonce))
-		.map_err(|_| ChannelError::DeriveFailed)?;
-
-	Ok((key, nonce))
-}
-
-fn derive_response_aead(
-	secret: &ResponseSecret,
-	encapsulated_key: &[u8; ENCAPSULATED_KEY_LEN],
-	response_nonce: &[u8; RESPONSE_NONCE_LEN],
-) -> Result<(Aes256Gcm, Nonce<Aes256Gcm>), ChannelError> {
-	let (key, nonce) = derive_response_key_nonce(secret, encapsulated_key, response_nonce)?;
-
-	Ok((
-		Aes256Gcm::new(&Key::<Aes256Gcm>::from(*key)),
-		Nonce::<Aes256Gcm>::from(nonce),
-	))
-}
-
-/// Responder-side boot keypair. Opens sealed requests and seals responses.
+/// Responder-side boot keypair: opens sealed requests and seals the matching responses.
 pub struct Responder {
 	domain: ChannelDomain,
-	secret_key: <Kem as KemTrait>::PrivateKey,
-	public_key: [u8; ENCRYPTION_KEY_LEN],
+	secret_key: SecretKey,
 }
 
 impl Responder {
-	/// Generates a fresh keypair from `rng`, serving `domain`.
-	///
-	/// # Panics
-	///
-	/// Panics if the KEM produces a public key that is not [`ENCRYPTION_KEY_LEN`] bytes.
-	#[must_use]
-	pub fn generate(domain: ChannelDomain, rng: &mut impl CryptoRng) -> Self {
-		let (secret_key, public_key) = Kem::gen_keypair_with_rng(rng);
-		let public_key = public_key
-			.to_bytes()
-			.as_slice()
-			.try_into()
-			.expect("X25519 public keys are 32 bytes");
-
-		Self {
-			domain,
-			secret_key,
-			public_key,
-		}
-	}
-
-	/// Returns the public key requesters seal to for this boot.
-	#[must_use]
-	pub const fn public_key(&self) -> [u8; ENCRYPTION_KEY_LEN] {
-		self.public_key
-	}
-
-	/// Returns the domain this responder serves.
-	#[must_use]
-	pub const fn domain(&self) -> ChannelDomain {
-		self.domain
-	}
-
-	/// Opens a sealed request and returns the plaintext plus a [`ResponseSealer`] for the reply.
+	/// Generates a fresh keypair serving `domain`.
 	///
 	/// # Errors
 	///
-	/// Returns [`ChannelError`] if the request is too short, the encapsulated key is unusable, the
-	/// ciphertext fails authentication, or the response secret cannot be exported.
-	pub fn open(
-		&self,
-		request: &SealedRequest,
-	) -> Result<(Zeroizing<Vec<u8>>, ResponseSealer), ChannelError> {
-		let body = request.as_ref();
-		if body.len() <= ENCAPSULATED_KEY_LEN + AEAD_TAG_LEN {
-			return Err(ChannelError::Truncated);
-		}
-		let (encapsulated, ciphertext) = body.split_at(ENCAPSULATED_KEY_LEN);
-		let encapsulated_key: [u8; ENCAPSULATED_KEY_LEN] = encapsulated
-			.try_into()
-			.map_err(|_| ChannelError::Truncated)?;
+	/// Fails if the operating system CSPRNG is unavailable.
+	pub fn generate(domain: ChannelDomain) -> Result<Self, ChannelError> {
+		Ok(Self {
+			domain,
+			secret_key: SecretKey::generate()?,
+		})
+	}
 
-		let encapped = <Kem as KemTrait>::EncappedKey::from_bytes(encapsulated)
-			.map_err(|_| ChannelError::InvalidEncapsulatedKey)?;
+	/// The public key requesters seal to for this boot. Attest these bytes.
+	#[must_use]
+	pub fn public_key(&self) -> Vec<u8> {
+		self.secret_key.public_key().to_bytes()
+	}
 
-		let info = self.domain.info(&self.public_key);
-		let mut context = setup_receiver::<ChannelAead, Kdf, Kem>(
-			&OpModeR::Base,
-			&self.secret_key,
-			&encapped,
-			&info,
-		)
-		.map_err(|_| ChannelError::InvalidEncapsulatedKey)?;
-
-		let plaintext = context
-			.open(ciphertext, &[])
-			.map_err(|_| ChannelError::OpenFailed)?;
-
-		let mut secret = Zeroizing::new([0u8; RESPONSE_NONCE_LEN]);
-		context
-			.export(&self.domain.exporter_label(), secret.as_mut_slice())
-			.map_err(|_| ChannelError::ExportFailed)?;
+	/// Opens a sealed request, returning the plaintext and a sealer for its one response.
+	///
+	/// # Errors
+	///
+	/// Fails if the request was not sealed to this boot under this domain, or carries no reply
+	/// key.
+	pub fn open(&self, request: &[u8]) -> Result<(Vec<u8>, ResponseSealer), ChannelError> {
+		let body = SecretKey::unseal(&self.secret_key, request, Some(&self.domain.info(REQUEST)))?;
+		let Some((reply_key, plaintext)) = body.split_first_chunk::<REPLY_KEY_LEN>() else {
+			return Err(ChannelError::MissingReplyKey);
+		};
 
 		Ok((
-			Zeroizing::new(plaintext),
+			plaintext.to_vec(),
 			ResponseSealer {
-				secret,
-				encapsulated_key,
+				domain: self.domain,
+				reply_key: PublicKey::from_bytes(reply_key)?,
 			},
 		))
 	}
 }
 
-/// Requester-side handle built from a verified encryption public key.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// Requester-side handle built from an attested encryption key.
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Requester {
 	domain: ChannelDomain,
-	public_key: [u8; ENCRYPTION_KEY_LEN],
+	public_key: PublicKey,
 }
 
 impl Requester {
-	/// Builds a requester from an attested encryption public key.
-	///
-	/// This is a format check, not point validation: every 32-byte string decodes as an X25519
-	/// public key (RFC 7748 clamps on use), so a key yielding no valid shared secret — the
-	/// all-zero point, for instance — is only rejected when [`Self::seal`] runs encapsulation.
+	/// Builds a requester for the public key a verified attestation carried.
 	///
 	/// # Errors
 	///
-	/// Returns [`ChannelError::InvalidEncryptionKey`] if `public_key` cannot be decoded.
-	pub fn new(
-		domain: ChannelDomain,
-		public_key: [u8; ENCRYPTION_KEY_LEN],
-	) -> Result<Self, ChannelError> {
-		<Kem as KemTrait>::PublicKey::from_bytes(&public_key)
-			.map_err(|_| ChannelError::InvalidEncryptionKey)?;
-		Ok(Self { domain, public_key })
+	/// Fails if `public_key` is not a valid X-Wing encapsulation key.
+	pub fn new(domain: ChannelDomain, public_key: &[u8]) -> Result<Self, ChannelError> {
+		Ok(Self {
+			domain,
+			public_key: PublicKey::from_bytes(public_key)?,
+		})
 	}
 
-	/// Builds a requester from the public key an attestation document carried.
+	/// Seals one request, returning the wire bytes and an opener for its one response.
 	///
 	/// # Errors
 	///
-	/// Returns [`ChannelError::InvalidEncryptionKey`] if `public_key` is not exactly
-	/// [`ENCRYPTION_KEY_LEN`] bytes or cannot be decoded; see [`Self::new`] for what decoding
-	/// does and does not validate.
-	pub fn from_attestation(
-		domain: ChannelDomain,
-		public_key: &[u8],
-	) -> Result<Self, ChannelError> {
-		let public_key: [u8; ENCRYPTION_KEY_LEN] = public_key
-			.try_into()
-			.map_err(|_| ChannelError::InvalidEncryptionKey)?;
-		Self::new(domain, public_key)
-	}
+	/// Fails if the operating system CSPRNG is unavailable, or the box refuses to seal.
+	pub fn seal(&self, plaintext: &[u8]) -> Result<(Vec<u8>, ResponseOpener), ChannelError> {
+		let reply_key = SecretKey::generate()?;
+		let mut body = reply_key.public_key().to_bytes();
+		body.extend_from_slice(plaintext);
 
-	/// Returns the raw X25519 public key.
-	#[must_use]
-	pub const fn public_key(&self) -> [u8; ENCRYPTION_KEY_LEN] {
-		self.public_key
-	}
-
-	/// Returns the domain this requester seals under.
-	#[must_use]
-	pub const fn domain(&self) -> ChannelDomain {
-		self.domain
-	}
-
-	/// Seals one request, returning the wire body and a [`ResponseOpener`] for the reply.
-	///
-	/// # Errors
-	///
-	/// Returns [`ChannelError`] if the public key yields no shared secret, or the AEAD refuses to
-	/// seal.
-	pub fn seal(
-		&self,
-		plaintext: &[u8],
-		rng: &mut impl CryptoRng,
-	) -> Result<(SealedRequest, ResponseOpener), ChannelError> {
-		let public_key = <Kem as KemTrait>::PublicKey::from_bytes(&self.public_key)
-			.map_err(|_| ChannelError::InvalidEncryptionKey)?;
-
-		let info = self.domain.info(&self.public_key);
-		let (encapped, mut context) =
-			setup_sender_with_rng::<ChannelAead, Kdf, Kem>(&OpModeS::Base, &public_key, &info, rng)
-				.map_err(|_| ChannelError::InvalidEncryptionKey)?;
-
-		let ciphertext = context
-			.seal(plaintext, &[])
-			.map_err(|_| ChannelError::SealFailed)?;
-
-		let encapsulated = encapped.to_bytes();
-		let encapsulated_key: [u8; ENCAPSULATED_KEY_LEN] = encapsulated
-			.as_slice()
-			.try_into()
-			.map_err(|_| ChannelError::InvalidEncapsulatedKey)?;
-
-		let mut body = encapsulated_key.to_vec();
-		body.extend_from_slice(&ciphertext);
+		let request = PublicKey::seal(&self.public_key, &body, Some(&self.domain.info(REQUEST)))?;
 
 		Ok((
-			SealedRequest(body),
+			request,
 			ResponseOpener {
-				exporter_label: self.domain.exporter_label(),
-				context,
-				encapsulated_key,
+				domain: self.domain,
+				reply_key,
 			},
 		))
 	}
 }
 
-/// Opens the response belonging to one [`Requester::seal`] call.
+/// Opens the one response belonging to a [`Requester::seal`] call.
 pub struct ResponseOpener {
-	exporter_label: Vec<u8>,
-	context: AeadCtxS<ChannelAead, Kdf, Kem>,
-	encapsulated_key: [u8; ENCAPSULATED_KEY_LEN],
+	domain: ChannelDomain,
+	reply_key: SecretKey,
 }
 
 impl ResponseOpener {
@@ -440,571 +155,217 @@ impl ResponseOpener {
 	///
 	/// # Errors
 	///
-	/// Returns [`ChannelError`] if the response is too short, the secret cannot be exported or
-	/// expanded, or the ciphertext fails authentication.
-	pub fn open(&self, response: &SealedResponse) -> Result<Zeroizing<Vec<u8>>, ChannelError> {
-		let sealed = response.as_ref();
-		if sealed.len() <= RESPONSE_NONCE_LEN + AEAD_TAG_LEN {
-			return Err(ChannelError::Truncated);
-		}
-		let (response_nonce, ciphertext) = sealed.split_at(RESPONSE_NONCE_LEN);
-		let response_nonce: [u8; RESPONSE_NONCE_LEN] = response_nonce
-			.try_into()
-			.map_err(|_| ChannelError::Truncated)?;
-
-		let mut secret = Zeroizing::new([0u8; RESPONSE_NONCE_LEN]);
-		self.context
-			.export(&self.exporter_label, secret.as_mut_slice())
-			.map_err(|_| ChannelError::ExportFailed)?;
-
-		let (cipher, nonce) =
-			derive_response_aead(&secret, &self.encapsulated_key, &response_nonce)?;
-
-		let plaintext = cipher
-			.decrypt(&nonce, ciphertext)
-			.map_err(|_| ChannelError::OpenFailed)?;
-
-		Ok(Zeroizing::new(plaintext))
+	/// Fails if the response was not sealed to this request.
+	pub fn open(&self, response: &[u8]) -> Result<Vec<u8>, ChannelError> {
+		Ok(SecretKey::unseal(
+			&self.reply_key,
+			response,
+			Some(&self.domain.info(RESPONSE)),
+		)?)
 	}
 }
 
 /// Seals the one response belonging to a [`Responder::open`] call.
 pub struct ResponseSealer {
-	secret: ResponseSecret,
-	encapsulated_key: [u8; ENCAPSULATED_KEY_LEN],
+	domain: ChannelDomain,
+	reply_key: PublicKey,
 }
 
 impl ResponseSealer {
-	/// Seals one response, per RFC 9458 §4.4.
+	/// Seals one response.
 	///
 	/// # Errors
 	///
-	/// Returns [`ChannelError`] if the key or nonce cannot be expanded, or the AEAD refuses to
-	/// seal.
-	pub fn seal(
-		self,
-		plaintext: &[u8],
-		rng: &mut impl CryptoRng,
-	) -> Result<SealedResponse, ChannelError> {
-		let mut response_nonce = [0u8; RESPONSE_NONCE_LEN];
-		rng.fill_bytes(&mut response_nonce);
-
-		let (cipher, nonce) =
-			derive_response_aead(&self.secret, &self.encapsulated_key, &response_nonce)?;
-
-		let ciphertext = cipher
-			.encrypt(&nonce, plaintext)
-			.map_err(|_| ChannelError::SealFailed)?;
-
-		let mut sealed = response_nonce.to_vec();
-		sealed.extend_from_slice(&ciphertext);
-
-		Ok(SealedResponse(sealed))
+	/// Fails if the operating system CSPRNG is unavailable, or the box refuses to seal.
+	pub fn seal(self, plaintext: &[u8]) -> Result<Vec<u8>, ChannelError> {
+		Ok(PublicKey::seal(
+			&self.reply_key,
+			plaintext,
+			Some(&self.domain.info(RESPONSE)),
+		)?)
 	}
 }
 
 #[cfg(test)]
 mod tests {
-	use getrandom::SysRng;
-	use hpke::rand_core::UnwrapErr;
-
 	use super::{
-		ChannelDomain, ChannelError, Requester, Responder, ResponseOpener, SealedRequest,
-		SealedResponse, AEAD_TAG_LEN, ENCAPSULATED_KEY_LEN, EXPORTER_LABEL_SUFFIX,
-		RESPONSE_NONCE_LEN,
+		ChannelDomain, ChannelError, REPLY_KEY_LEN, REQUEST, RESPONSE, Requester, Responder,
 	};
+	use quantum_box::{Error, SecretKey};
 
 	const TEST_DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/test", 1);
 
-	fn seal_to(responder: &Responder, plaintext: &[u8]) -> (SealedRequest, ResponseOpener) {
-		let requester =
-			Requester::new(responder.domain(), responder.public_key()).expect("valid key");
-		let mut rng = UnwrapErr(SysRng);
-		let (request, opener) = requester
-			.seal(plaintext, &mut rng)
-			.expect("sealing should succeed");
-		(request, opener)
+	fn responder() -> Responder {
+		Responder::generate(TEST_DOMAIN).expect("CSPRNG available")
 	}
 
-	fn test_rng() -> UnwrapErr<SysRng> {
-		UnwrapErr(SysRng)
+	fn requester_for(responder: &Responder, domain: ChannelDomain) -> Requester {
+		Requester::new(domain, &responder.public_key()).expect("attested key parses")
 	}
 
 	#[test]
-	fn requester_from_attestation_matches_new() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let from_attestation = Requester::from_attestation(TEST_DOMAIN, &responder.public_key())
-			.expect("should parse");
-		let from_new = Requester::new(TEST_DOMAIN, responder.public_key()).expect("should parse");
-		assert_eq!(from_attestation, from_new);
+	fn round_trips_a_request_and_its_response() {
+		let responder = responder();
+		let (request, opener) = requester_for(&responder, TEST_DOMAIN)
+			.seal(b"inputs")
+			.expect("seal");
+
+		let (plaintext, sealer) = responder.open(&request).expect("open");
+		assert_eq!(plaintext, b"inputs");
+
+		let response = sealer.seal(b"result").expect("seal response");
+		assert_eq!(opener.open(&response).expect("open response"), b"result");
+	}
+
+	/// Guards the framing constant against an X-Wing key size change upstream.
+	#[test]
+	fn a_reply_key_is_exactly_the_framed_length() {
+		let key = SecretKey::from_seed(&[0u8; 32]).public_key().to_bytes();
+		assert_eq!(key.len(), REPLY_KEY_LEN);
 	}
 
 	#[test]
-	fn rejects_a_non_32_byte_attestation_key() {
+	fn info_binds_name_version_and_direction() {
 		assert_eq!(
-			Requester::from_attestation(TEST_DOMAIN, &[0u8; 31]).err(),
-			Some(ChannelError::InvalidEncryptionKey)
+			TEST_DOMAIN.info(REQUEST),
+			[b"pontifex/test".as_ref(), &[1, REQUEST]].concat()
+		);
+		assert_ne!(TEST_DOMAIN.info(REQUEST), TEST_DOMAIN.info(RESPONSE));
+		assert_ne!(
+			TEST_DOMAIN.info(REQUEST),
+			ChannelDomain::new("pontifex/other", 1).info(REQUEST)
+		);
+		assert_ne!(
+			TEST_DOMAIN.info(REQUEST),
+			ChannelDomain::new("pontifex/test", 2).info(REQUEST)
 		);
 	}
 
 	#[test]
-	fn info_binds_name_version_and_key() {
-		let key = [7u8; 32];
-		let info = TEST_DOMAIN.info(&key);
-		let (name, rest) = info.split_at(TEST_DOMAIN.name().len());
-		assert_eq!(name, TEST_DOMAIN.name().as_bytes());
-		assert_eq!(rest, [&[TEST_DOMAIN.version()][..], &key[..]].concat());
-	}
-
-	#[test]
-	fn info_separates_names_versions_and_keys() {
-		let key = [7u8; 32];
-		let other_name = ChannelDomain::new("pontifex/other", TEST_DOMAIN.version());
-		let next_version = ChannelDomain::new(TEST_DOMAIN.name(), TEST_DOMAIN.version() + 1);
-
-		assert_ne!(TEST_DOMAIN.info(&key), other_name.info(&key));
-		assert_ne!(TEST_DOMAIN.info(&key), next_version.info(&key));
-		assert_ne!(TEST_DOMAIN.info(&key), TEST_DOMAIN.info(&[8u8; 32]));
-	}
-
-	#[test]
-	fn exporter_label_follows_the_name() {
+	fn rejects_an_unparseable_attested_key() {
 		assert_eq!(
-			TEST_DOMAIN.exporter_label(),
-			[TEST_DOMAIN.name().as_bytes(), EXPORTER_LABEL_SUFFIX].concat()
+			Requester::new(TEST_DOMAIN, &[0u8; 32]),
+			Err(ChannelError::SealedBox(Error::KeyFormat))
 		);
-		assert_ne!(
-			TEST_DOMAIN.exporter_label(),
-			ChannelDomain::new("pontifex/other", 1).exporter_label()
-		);
-	}
-
-	#[test]
-	fn separate_responders_receive_separate_public_keys() {
-		assert_ne!(
-			Responder::generate(TEST_DOMAIN, &mut test_rng()).public_key(),
-			Responder::generate(TEST_DOMAIN, &mut test_rng()).public_key()
-		);
-	}
-
-	#[test]
-	fn public_key_is_stable_for_one_responder() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		assert_eq!(responder.public_key(), responder.public_key());
-	}
-
-	#[test]
-	fn round_trips_a_request_and_its_sealed_response() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, opener) = seal_to(&responder, b"request inputs");
-
-		let (plaintext, sealer) = responder.open(&request).expect("should open");
-		assert_eq!(&plaintext[..], b"request inputs");
-
-		let response = sealer
-			.seal(b"statement", &mut test_rng())
-			.expect("sealing should succeed");
-
-		assert_eq!(&*opener.open(&response).unwrap(), b"statement".as_ref());
-	}
-
-	#[test]
-	fn each_response_draws_a_fresh_nonce() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, opener) = seal_to(&responder, b"request inputs");
-
-		let (_, first_sealer) = responder.open(&request).expect("should open");
-		let (_, second_sealer) = responder.open(&request).expect("should open");
-		let first = first_sealer
-			.seal(b"statement", &mut test_rng())
-			.expect("should seal");
-		let second = second_sealer
-			.seal(b"statement", &mut test_rng())
-			.expect("should seal");
-
-		assert_ne!(
-			first.as_ref()[..RESPONSE_NONCE_LEN],
-			second.as_ref()[..RESPONSE_NONCE_LEN],
-		);
-		assert_ne!(
-			first.as_ref()[RESPONSE_NONCE_LEN..],
-			second.as_ref()[RESPONSE_NONCE_LEN..],
-		);
-		assert_eq!(&*opener.open(&first).unwrap(), b"statement".as_ref());
-		assert_eq!(&*opener.open(&second).unwrap(), b"statement".as_ref());
 	}
 
 	#[test]
 	fn rejects_a_request_sealed_to_another_boot() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let other = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, _) = seal_to(&other, b"request inputs");
-
-		assert_eq!(
-			responder.open(&request).err(),
-			Some(ChannelError::OpenFailed)
-		);
-	}
-
-	#[test]
-	fn rejects_a_request_bound_to_another_channel_version() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let next_version = ChannelDomain::new(TEST_DOMAIN.name(), TEST_DOMAIN.version() + 1);
-		let requester = Requester::new(next_version, responder.public_key()).expect("valid key");
-		let (request, _) = requester
-			.seal(b"request inputs", &mut test_rng())
-			.expect("sealing should succeed");
-
-		assert_eq!(
-			responder.open(&request).err(),
-			Some(ChannelError::OpenFailed)
-		);
-	}
-
-	#[test]
-	fn rejects_a_request_sealed_under_another_domain_name() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let other_name = ChannelDomain::new("pontifex/other", TEST_DOMAIN.version());
-		let requester = Requester::new(other_name, responder.public_key()).expect("valid key");
-		let (request, _) = requester
-			.seal(b"request inputs", &mut test_rng())
-			.expect("sealing should succeed");
-
-		assert_eq!(
-			responder.open(&request).err(),
-			Some(ChannelError::OpenFailed)
-		);
-	}
-
-	#[test]
-	fn rejects_a_low_order_encapsulated_key() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, _) = seal_to(&responder, b"request inputs");
-		let mut body = request.into_bytes();
-		body[..ENCAPSULATED_KEY_LEN].fill(0);
-
-		assert_eq!(
-			responder.open(&SealedRequest(body)).err(),
-			Some(ChannelError::InvalidEncapsulatedKey)
-		);
-	}
-
-	#[test]
-	fn rejects_a_truncated_request_body() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-
-		for length in [0, ENCAPSULATED_KEY_LEN, ENCAPSULATED_KEY_LEN + AEAD_TAG_LEN] {
-			assert_eq!(
-				responder
-					.open(&SealedRequest::from_bytes(vec![0u8; length]))
-					.err(),
-				Some(ChannelError::Truncated),
-				"length {length}"
-			);
-		}
-	}
-
-	#[test]
-	fn rejects_a_tampered_request_ciphertext() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, _) = seal_to(&responder, b"request inputs");
-		let mut body = request.into_bytes();
-		body[ENCAPSULATED_KEY_LEN] ^= 0x01;
-
-		assert_eq!(
-			responder.open(&SealedRequest(body)).err(),
-			Some(ChannelError::OpenFailed)
-		);
-	}
-
-	#[test]
-	fn rejects_a_truncated_response() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-
-		for length in [0, RESPONSE_NONCE_LEN, RESPONSE_NONCE_LEN + AEAD_TAG_LEN] {
-			let (_, opener) = seal_to(&responder, b"request inputs");
-			assert_eq!(
-				opener
-					.open(&SealedResponse::from_bytes(vec![0u8; length]))
-					.err(),
-				Some(ChannelError::Truncated),
-				"length {length}"
-			);
-		}
-	}
-
-	#[test]
-	fn a_second_request_to_the_same_key_cannot_open_the_response() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, _) = seal_to(&responder, b"request inputs");
-		let (_, eavesdropper) = seal_to(&responder, b"unrelated");
-
-		let (_, sealer) = responder.open(&request).expect("should open");
-		let response = sealer
-			.seal(b"statement", &mut test_rng())
-			.expect("sealing should succeed");
-
-		assert_eq!(
-			eavesdropper.open(&response).err(),
-			Some(ChannelError::OpenFailed)
-		);
-	}
-
-	#[test]
-	fn rejects_a_tampered_response_ciphertext() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, opener) = seal_to(&responder, b"request inputs");
-		let (_, sealer) = responder.open(&request).expect("should open");
-
-		let response = sealer
-			.seal(b"statement", &mut test_rng())
-			.expect("sealing should succeed");
-		let mut body = response.into_bytes();
-		body[RESPONSE_NONCE_LEN] ^= 0x01;
-
-		assert_eq!(
-			opener.open(&SealedResponse(body)).err(),
-			Some(ChannelError::OpenFailed)
-		);
-	}
-
-	#[test]
-	fn rejects_a_tampered_response_nonce() {
-		let responder = Responder::generate(TEST_DOMAIN, &mut test_rng());
-		let (request, opener) = seal_to(&responder, b"request inputs");
-		let (_, sealer) = responder.open(&request).expect("should open");
-
-		let response = sealer
-			.seal(b"statement", &mut test_rng())
-			.expect("sealing should succeed");
-		let mut body = response.into_bytes();
-		body[0] ^= 0x01;
-
-		assert_eq!(
-			opener.open(&SealedResponse(body)).err(),
-			Some(ChannelError::OpenFailed)
-		);
-	}
-
-	#[test]
-	fn rejects_an_invalid_encryption_key() {
-		// All-zero encodes as a point but yields no valid shared secret at encapsulation.
-		let requester = Requester::new(TEST_DOMAIN, [0u8; 32]).expect("all-zero key encodes");
-		let result = requester.seal(b"request inputs", &mut test_rng());
-
-		assert_eq!(result.err(), Some(ChannelError::InvalidEncryptionKey));
-	}
-}
-
-/// Known-answer tests.
-///
-/// Three layers, each guarding a different failure mode:
-///
-/// 1. **Official RFC 9180 vector** for this module's exact suite — `mode_base`,
-///    DHKEM(X25519, HKDF-SHA256), HKDF-SHA256, AES-256-GCM — taken from the reference vector set
-///    the `hpke` crate ships (`test-vectors/origrfc-5f503c5.json`; the RFC's own appendix has no
-///    vector for this AEAD with X25519). Catches a broken build of the suite itself: upstream's
-///    vector tests never run in this repository's CI.
-/// 2. **Independent HKDF vector** for the response derivation, computed with a stdlib-only
-///    Python HMAC implementation that shares no code with the `hkdf` crate. Pins the
-///    `enc || response_nonce` salt construction and the `"key"`/`"nonce"` labels.
-/// 3. **Deterministic wire vectors** for the full channel under a fixed RNG. Self-generated, so
-///    they verify nothing about correctness — they freeze the wire contract (the `info`
-///    construction, the exporter label, the suite, framing) so any accidental change fails a
-///    test instead of shipping silently.
-#[cfg(test)]
-mod kat {
-	use core::convert::Infallible;
-
-	use hex_literal::hex;
-	use hpke::rand_core::{TryCryptoRng, TryRng};
-
-	use super::*;
-
-	/// Yields exactly the queued bytes, in order. Panics when drained, so a test that consumes
-	/// more randomness than its vector provides fails loudly instead of diverging silently.
-	struct FixedRng(Vec<u8>);
-
-	impl FixedRng {
-		fn new(bytes: &[u8]) -> Self {
-			Self(bytes.to_vec())
-		}
-	}
-
-	impl TryRng for FixedRng {
-		type Error = Infallible;
-
-		fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
-			let mut bytes = [0u8; 4];
-			self.try_fill_bytes(&mut bytes)?;
-			Ok(u32::from_le_bytes(bytes))
-		}
-
-		fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-			let mut bytes = [0u8; 8];
-			self.try_fill_bytes(&mut bytes)?;
-			Ok(u64::from_le_bytes(bytes))
-		}
-
-		fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-			assert!(
-				self.0.len() >= dst.len(),
-				"FixedRng drained: the test consumed more randomness than its vector provides"
-			);
-			let rest = self.0.split_off(dst.len());
-			dst.copy_from_slice(&self.0);
-			self.0 = rest;
-			Ok(())
-		}
-	}
-
-	impl TryCryptoRng for FixedRng {}
-
-	// RFC 9180 reference vector: mode_base, kem_id 0x0020, kdf_id 0x0001, aead_id 0x0002.
-	// Source: the `hpke` crate's `test-vectors/origrfc-5f503c5.json`.
-	const IKM_E: [u8; 32] =
-		hex!("2cd7c601cefb3d42a62b04b7a9041494c06c7843818e0ce28a8f704ae7ab20f9");
-	const IKM_R: [u8; 32] =
-		hex!("dac33b0e9db1b59dbbea58d59a14e7b5896e9bdf98fad6891e99d1686492b9ee");
-	const PK_RM: [u8; 32] =
-		hex!("430f4b9859665145a6b1ba274024487bd66f03a2dd577d7753c68d7d7d00c00c");
-	const ENC: [u8; 32] = hex!("6c93e09869df3402d7bf231bf540fadd35cd56be14f97178f0954db94b7fc256");
-	/// "Ode on a Grecian Urn"
-	const VECTOR_INFO: &[u8] = &hex!("4f6465206f6e2061204772656369616e2055726e");
-	/// "Beauty is truth, truth beauty"
-	const VECTOR_PT: &[u8] = &hex!("4265617574792069732074727574682c20747275746820626561757479");
-	/// "Count-0"
-	const VECTOR_AAD: &[u8] = &hex!("436f756e742d30");
-	const VECTOR_CT: &[u8] = &hex!(
-		"e5d84cd531cfb583096e7cfa9641bd3079cf3a91cda813c52deb5f512be9931980a41de125a925cdad859d5b7a"
-	);
-	const EXPORT_EMPTY_CONTEXT: [u8; 32] =
-		hex!("ded6cffafaea6b812cbf3e241e88332adbc077aca81512914213810ee291770a");
-	const EXPORT_TEST_CONTEXT: [u8; 32] =
-		hex!("7c5ded445732c14fe09727d29b4251c0fd38455fe8440571e687f0886aac94d2");
-
-	/// Layer 1: the `hpke` crate, built with this crate's feature set, reproduces the official
-	/// vector for the exact suite this module pins.
-	///
-	/// The ephemeral is reproducible because DHKEM's `encap_with_rng` is
-	/// `DeriveKeyPair(random(Nsk))`: feeding the RNG the vector's `ikmE` yields the vector's
-	/// ephemeral key.
-	#[test]
-	fn hpke_suite_matches_the_official_vector() {
-		// Recipient keypair from ikmR.
-		let (sk_r, pk_r) = <Kem as KemTrait>::derive_keypair(&IKM_R);
-		assert_eq!(pk_r.to_bytes().as_slice(), PK_RM, "pkRm");
-
-		// Sender: ephemeral from ikmE, then seal the vector's first plaintext.
-		let pk_recip = <Kem as KemTrait>::PublicKey::from_bytes(&PK_RM).expect("pkRm decodes");
-		let mut rng = FixedRng::new(&IKM_E);
-		let (encapped, mut sender) = setup_sender_with_rng::<ChannelAead, Kdf, Kem>(
-			&OpModeS::Base,
-			&pk_recip,
-			VECTOR_INFO,
-			&mut rng,
-		)
-		.expect("sender setup");
-		assert_eq!(encapped.to_bytes().as_slice(), ENC, "enc");
-		let ciphertext = sender.seal(VECTOR_PT, VECTOR_AAD).expect("seal");
-		assert_eq!(ciphertext.as_slice(), VECTOR_CT, "ct[0]");
-
-		// Receiver: open the vector ciphertext.
-		let encapped = <Kem as KemTrait>::EncappedKey::from_bytes(&ENC).expect("enc decodes");
-		let mut receiver =
-			setup_receiver::<ChannelAead, Kdf, Kem>(&OpModeR::Base, &sk_r, &encapped, VECTOR_INFO)
-				.expect("receiver setup");
-		assert_eq!(
-			receiver
-				.open(VECTOR_CT, VECTOR_AAD)
-				.expect("open")
-				.as_slice(),
-			VECTOR_PT,
-			"pt[0]"
-		);
-
-		// Exporter, both sides.
-		let mut exported = [0u8; 32];
-		receiver.export(b"", &mut exported).expect("export");
-		assert_eq!(exported, EXPORT_EMPTY_CONTEXT, "export(\"\")");
-		sender
-			.export(b"TestContext", &mut exported)
-			.expect("export");
-		assert_eq!(exported, EXPORT_TEST_CONTEXT, "export(\"TestContext\")");
-	}
-
-	/// Layer 2: the response `Extract`/`Expand` chain matches a vector computed with a
-	/// stdlib-only Python HMAC implementation — independent of the `hkdf` crate.
-	///
-	/// ```text
-	/// prk   = HMAC-SHA256(salt = enc || response_nonce, ikm = secret)
-	/// key   = HKDF-Expand(prk, "key", 32)
-	/// nonce = HKDF-Expand(prk, "nonce", 12)
-	/// ```
-	#[test]
-	fn response_derivation_matches_an_independent_hkdf() {
-		let secret: ResponseSecret =
-			Zeroizing::new(core::array::from_fn(|i| u8::try_from(i).unwrap()));
-		let encapsulated_key: [u8; ENCAPSULATED_KEY_LEN] =
-			core::array::from_fn(|i| u8::try_from(0x20 + i).unwrap());
-		let response_nonce: [u8; RESPONSE_NONCE_LEN] =
-			core::array::from_fn(|i| u8::try_from(0x40 + i).unwrap());
-
-		let (key, nonce) = derive_response_key_nonce(&secret, &encapsulated_key, &response_nonce)
-			.expect("derivation");
-
-		assert_eq!(
-			*key,
-			hex!("40ec528847cd4e928449f2ed1a70a7d1e8ee317d5e900424fc1dd5b0475b97f7")
-		);
-		assert_eq!(nonce, hex!("f8b0ce9466f27aa6243c65f9"));
-	}
-
-	const PINNED_DOMAIN: ChannelDomain = ChannelDomain::new("pontifex/kat", 1);
-
-	/// Layer 3 (regression, self-generated): the full channel under a fixed RNG produces these
-	/// exact wire bytes. Freezes the `info` construction, the exporter label, the suite, and
-	/// framing — any of them changing alters the bytes and fails this test, which is the point:
-	/// the wire contract only moves together with the domain's version.
-	#[test]
-	fn wire_bytes_are_frozen_under_a_fixed_rng() {
-		let responder = Responder::generate(PINNED_DOMAIN, &mut FixedRng::new(&[0x11; 32]));
-		assert_eq!(responder.public_key(), PINNED_PUBLIC_KEY, "responder key");
-
-		let requester = Requester::new(PINNED_DOMAIN, responder.public_key()).expect("valid key");
-		let (request, opener) = requester
-			.seal(b"request", &mut FixedRng::new(&[0x22; 32]))
+		let (request, _) = requester_for(&responder(), TEST_DOMAIN)
+			.seal(b"inputs")
 			.expect("seal");
-		assert_eq!(request.as_ref(), PINNED_REQUEST, "request bytes");
-
-		let (plaintext, sealer) = responder
-			.open(&SealedRequest::from_bytes(PINNED_REQUEST.to_vec()))
-			.expect("open");
-		assert_eq!(&plaintext[..], b"request");
-
-		let response = sealer
-			.seal(b"response", &mut FixedRng::new(&[0x33; 32]))
-			.expect("seal response");
-		assert_eq!(response.as_ref(), PINNED_RESPONSE, "response bytes");
 
 		assert_eq!(
-			&*opener
-				.open(&SealedResponse::from_bytes(PINNED_RESPONSE.to_vec()))
-				.expect("open response"),
-			b"response".as_ref()
+			responder().open(&request).err(),
+			Some(ChannelError::SealedBox(Error::Unseal))
 		);
 	}
 
-	const PINNED_PUBLIC_KEY: [u8; 32] =
-		hex!("1a239249ea74403babc01f32df9931a16f71ac8972c461d69fed15640e310639");
-	const PINNED_REQUEST: [u8; 55] = hex!(
-		"e3b9708aaa21a7f1e62a95ee28d1e5d60b0fceed6c68599013a54b318e9e0b15"
-		"87b0e1436d37cefc7e16eaad8c44b8ed52167a1590ea1d"
-	);
-	const PINNED_RESPONSE: [u8; 56] = hex!(
-		// The leading 32 bytes are the response_nonce exactly as drawn from the fixed RNG,
-		// confirming the `response_nonce || ciphertext` layout of RFC 9458 section 4.4 step 7.
-		"3333333333333333333333333333333333333333333333333333333333333333"
-		"2e6fd9ad62e341764bf330365541c95455743e6f683bda87"
-	);
+	#[test]
+	fn rejects_a_request_sealed_under_another_domain() {
+		let responder = responder();
+		for domain in [
+			ChannelDomain::new("pontifex/other", 1),
+			ChannelDomain::new("pontifex/test", 2),
+		] {
+			let (request, _) = requester_for(&responder, domain)
+				.seal(b"inputs")
+				.expect("seal");
+			assert_eq!(
+				responder.open(&request).err(),
+				Some(ChannelError::SealedBox(Error::Unseal)),
+				"{domain:?}"
+			);
+		}
+	}
+
+	#[test]
+	fn rejects_a_tampered_request() {
+		let responder = responder();
+		let (mut request, _) = requester_for(&responder, TEST_DOMAIN)
+			.seal(b"inputs")
+			.expect("seal");
+		*request.last_mut().expect("non-empty") ^= 0x01;
+
+		assert_eq!(
+			responder.open(&request).err(),
+			Some(ChannelError::SealedBox(Error::Unseal))
+		);
+	}
+
+	#[test]
+	fn rejects_a_truncated_request() {
+		assert_eq!(
+			responder().open(&[]).err(),
+			Some(ChannelError::SealedBox(Error::EmptyCiphertext))
+		);
+		assert_eq!(
+			responder().open(b"short").err(),
+			Some(ChannelError::SealedBox(Error::Decode))
+		);
+	}
+
+	/// The boot's key is public, so any sender can seal a body too short to carry a reply key.
+	#[test]
+	fn rejects_a_request_carrying_no_reply_key() {
+		let responder = responder();
+		let request = quantum_box::PublicKey::seal(
+			&responder.secret_key.public_key(),
+			b"no reply key here",
+			Some(&TEST_DOMAIN.info(REQUEST)),
+		)
+		.expect("seal");
+
+		assert_eq!(
+			responder.open(&request).err(),
+			Some(ChannelError::MissingReplyKey)
+		);
+	}
+
+	#[test]
+	fn rejects_a_tampered_response() {
+		let responder = responder();
+		let (request, opener) = requester_for(&responder, TEST_DOMAIN)
+			.seal(b"inputs")
+			.expect("seal");
+		let (_, sealer) = responder.open(&request).expect("open");
+
+		let mut response = sealer.seal(b"result").expect("seal response");
+		*response.last_mut().expect("non-empty") ^= 0x01;
+
+		assert_eq!(
+			opener.open(&response),
+			Err(ChannelError::SealedBox(Error::Unseal))
+		);
+	}
+
+	#[test]
+	fn another_requester_cannot_open_a_response() {
+		let responder = responder();
+		let requester = requester_for(&responder, TEST_DOMAIN);
+		let (request, _) = requester.seal(b"inputs").expect("seal");
+		let (_, eavesdropper) = requester.seal(b"unrelated").expect("seal");
+
+		let (_, sealer) = responder.open(&request).expect("open");
+		let response = sealer.seal(b"result").expect("seal response");
+
+		assert_eq!(
+			eavesdropper.open(&response),
+			Err(ChannelError::SealedBox(Error::Unseal))
+		);
+	}
+
+	#[test]
+	fn separate_boots_advertise_separate_keys() {
+		assert_ne!(responder().public_key(), responder().public_key());
+	}
+
+	#[test]
+	fn sealing_the_same_plaintext_twice_yields_different_bytes() {
+		let requester = requester_for(&responder(), TEST_DOMAIN);
+		let (first, _) = requester.seal(b"inputs").expect("seal");
+		let (second, _) = requester.seal(b"inputs").expect("seal");
+
+		assert_ne!(first, second);
+	}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,4 +93,13 @@ pub mod kms;
 #[cfg(feature = "http")]
 pub mod http;
 
+/// A confidential channel to a specific, measured enclave.
+#[cfg(feature = "channel")]
+pub mod channel;
+#[cfg(feature = "channel")]
+pub use channel::{
+	ChannelDomain, ChannelError, Requester, Responder, ResponseOpener, ResponseSealer,
+	SealedRequest, SealedResponse,
+};
+
 mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub mod http;
 pub mod channel;
 #[cfg(feature = "channel")]
 pub use channel::{
-	ChannelDomain, ChannelError, Requester, Responder, ResponseOpener, ResponseSealer,
+	ChannelConsumer, ChannelDomain, ChannelEnclave, ChannelError, ResponseOpener, ResponseSealer,
 };
 
 mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,6 @@ pub mod channel;
 #[cfg(feature = "channel")]
 pub use channel::{
 	ChannelDomain, ChannelError, Requester, Responder, ResponseOpener, ResponseSealer,
-	SealedRequest, SealedResponse,
 };
 
 mod utils;

--- a/src/nsm.rs
+++ b/src/nsm.rs
@@ -79,6 +79,19 @@ impl SecureModule {
 		nsm_process_request(self.fd, request)
 	}
 
+	/// The `module_id` of this enclave, formatted `i-<instance-id>-enc<enclave-id>`.
+	///
+	/// # Errors
+	///
+	/// Returns an error if the NSM driver returns an error.
+	pub fn module_id(&self) -> Result<String, AttestationError> {
+		match self.send(Request::DescribeNSM) {
+			Response::DescribeNSM { module_id, .. } => Ok(module_id),
+			Response::Error(code) => Err(AttestationError::Nsm(code)),
+			other => unreachable!("NSM answered DescribeNSM with {other:?}"),
+		}
+	}
+
 	/// Create an attestation document, and return it as a binary blob.
 	///
 	/// # Errors
@@ -178,7 +191,7 @@ impl Drop for SecureModule {
 	}
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "nsm"))]
 mod tests {
 	use super::*;
 


### PR DESCRIPTION
### Motivation
A very common pattern is for a consumer to communicate with an enclave where such communication must be private. Given the host is outside the trust boundary, a secure "channel" is created where a consumer can send an arbitrary payload to an enclave and receive the response.

### Changes
In essence this is simply using [quantum boxes](https://github.com/worldcoin/quantum-box) to end-to-end encrypt request/responses, but it introduces a standard flow that gets rid of common footguns.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces new cryptographic wire protocol and secret handling; misuse (skipping attestation verification, trusting unattested responses) could expose or mis-route sensitive enclave traffic.
> 
> **Overview**
> Adds an optional **`channel`** feature that standardizes **end-to-end encrypted** request/response traffic between a consumer and a Nitro enclave using **`quantum-box`** (HPKE / X-Wing), with a versioned **`ChannelDomain`**, per-request response keys, and **`zeroize`** for sensitive material.
> 
> The enclave side (`ChannelEnclave`) generates a boot keypair, opens sealed requests, and seals one reply per request; the consumer (`ChannelConsumer` / `ResponseOpener`) seals to an attested public key and opens the matching response. Docs call out that **responses are not attested**, **attestation is not verified in this module**, and **replay protection is not built in**.
> 
> **`Cargo.toml`** wires the feature and makes **`tokio-vsock`** / **`rmp-serde`** optional behind `client`/`server`/`_vsock-https`. **`SecureModule::module_id()`** is added for enclave identity. CI runs **`cargo hack check --each-feature`**; **CODEOWNERS** moves under **`.github`** with an extra owner; Dependabot gets another assignee and a cooldown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12c406f4be92d9e230b5eb381df58fc1c4f25fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->