### PR TITLE
fix: improve crate docs & remove connector cache limit

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -9,8 +9,6 @@ use hyper_util::{
 use tokio_vsock::VsockAddr;
 
 use crate::utils::http::vsock_proxy_http2;
-
-// Both appear in `HttpClient`, so callers need to be able to name them.
 pub use crate::utils::http::{ConnectTimeout, VSockClientBuilder};
 
 /// The CID of the vsock proxy.
@@ -80,10 +78,8 @@ where
 	)
 }
 
-/// Configuration for an HTTPS client that tunnels all requests through the host's vsock proxy and only uses HTTP/2.
-///
-/// Build from [`Default`] and adjust what you need; the struct is `non_exhaustive` so that adding a
-/// knob later is not a breaking change.
+/// Configuration for an HTTPS client that tunnels all requests through the host's
+/// vsock proxy and only uses HTTP/2.
 #[non_exhaustive]
 pub struct Http2ClientConfig {
 	/// Initial HTTP/2 stream window size. `None` leaves hyper's default in place.
@@ -125,8 +121,6 @@ where
 	let mut builder = Client::builder(TokioExecutor::new());
 
 	builder
-		// Unlike hyper 0.14, hyper-util does not install a timer of its own, and silently drops
-		// keep-alives and pool idle timeouts without one.
 		.timer(TokioTimer::new())
 		.pool_timer(TokioTimer::new())
 		.http2_only(true)

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -3,10 +3,7 @@ use std::{
 	collections::HashMap,
 	error::Error,
 	io,
-	sync::{
-		PoisonError, RwLock,
-		atomic::{AtomicBool, Ordering},
-	},
+	sync::{PoisonError, RwLock},
 	time::Duration,
 };
 
@@ -122,17 +119,12 @@ struct Timeouts {
 }
 
 const MAX_IDLE_CONNECTIONS: usize = 8;
-const MAX_CACHED_CONNECTORS: usize = 8;
 
 /// Routes the AWS SDK's HTTP traffic through the host's vsock proxy.
-///
-/// The orchestrator asks for a connector on every request attempt, so connectors are cached to
-/// keep the underlying connection pool alive across requests.
 #[derive(Debug)]
 struct VSockHttpClient {
 	address: VsockAddr,
 	connectors: RwLock<HashMap<Timeouts, SharedHttpConnector>>,
-	cache_full_warned: AtomicBool,
 }
 
 impl VSockHttpClient {
@@ -140,16 +132,6 @@ impl VSockHttpClient {
 		Self {
 			address,
 			connectors: RwLock::default(),
-			cache_full_warned: AtomicBool::new(false),
-		}
-	}
-
-	fn warn_cache_full(&self) {
-		if !self.cache_full_warned.swap(true, Ordering::Relaxed) {
-			tracing::warn!(
-				cap = MAX_CACHED_CONNECTORS,
-				"too many distinct timeout configurations; further ones get their own pool"
-			);
 		}
 	}
 }
@@ -180,13 +162,6 @@ impl HttpClient for VSockHttpClient {
 			.write()
 			.unwrap_or_else(PoisonError::into_inner);
 
-		if connectors.len() >= MAX_CACHED_CONNECTORS && !connectors.contains_key(&timeouts) {
-			drop(connectors);
-			self.warn_cache_full();
-
-			return connector;
-		}
-
 		connectors.entry(timeouts).or_insert(connector).clone()
 	}
 
@@ -204,14 +179,8 @@ struct VSockConnector {
 	read_timeout: Option<Duration>,
 }
 
-#[cfg(test)]
-static CONNECTORS_BUILT: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
 impl VSockConnector {
 	fn new(address: VsockAddr, timeouts: Timeouts) -> Self {
-		#[cfg(test)]
-		CONNECTORS_BUILT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-
 		let mut builder = Client::builder(TokioExecutor::new());
 
 		builder
@@ -529,9 +498,7 @@ mod tests {
 		let client = VSockHttpClient::new(VsockAddr::new(VSOCK_PROXY_CID, 8000));
 		let components = RuntimeComponentsBuilder::for_tests().build().unwrap();
 
-		counting_connectors(|| {
-			client.http_connector(&HttpConnectorSettings::builder().build(), &components);
-		});
+		client.http_connector(&HttpConnectorSettings::builder().build(), &components);
 
 		let timeouts = {
 			let connectors = client
@@ -548,38 +515,15 @@ mod tests {
 
 	#[test]
 	fn the_two_timeouts_are_not_transposed() {
-		let mut connector = None;
-
-		counting_connectors(|| {
-			connector = Some(VSockConnector::new(
-				VsockAddr::new(VSOCK_PROXY_CID, 8000),
-				Timeouts {
-					connect: Some(Duration::from_secs(3)),
-					read: Some(Duration::from_secs(17)),
-				},
-			));
-		});
-
-		assert_eq!(
-			connector.expect("built").read_timeout,
-			Some(Duration::from_secs(17))
+		let connector = VSockConnector::new(
+			VsockAddr::new(VSOCK_PROXY_CID, 8000),
+			Timeouts {
+				connect: Some(Duration::from_secs(3)),
+				read: Some(Duration::from_secs(17)),
+			},
 		);
-	}
 
-	/// `CONNECTORS_BUILT` is process-wide, so every test that can build a connector has to go
-	/// through this or the counting tests race each other.
-	static COUNTER_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-	/// Runs `body` with exclusive access to `CONNECTORS_BUILT`, returning how many connectors it
-	/// built.
-	fn counting_connectors(body: impl FnOnce()) -> usize {
-		use std::sync::atomic::Ordering;
-
-		let _guard = COUNTER_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
-		let before = CONNECTORS_BUILT.load(Ordering::Relaxed);
-		body();
-
-		CONNECTORS_BUILT.load(Ordering::Relaxed) - before
+		assert_eq!(connector.read_timeout, Some(Duration::from_secs(17)));
 	}
 
 	/// Re-resolving a connector has to hand back the existing one; building a fresh one would give
@@ -597,34 +541,9 @@ mod tests {
 			.connect_timeout(Duration::from_secs(7))
 			.build();
 
-		let built = counting_connectors(|| {
-			client.http_connector(&settings, &components);
-			client.http_connector(&settings, &components);
-			client.http_connector(&other, &components);
-		});
-
-		assert_eq!(
-			built, 2,
-			"two distinct timeout configurations, so exactly two connectors"
-		);
-	}
-
-	#[test]
-	fn the_connector_cache_is_bounded() {
-		use aws_smithy_runtime_api::client::runtime_components::RuntimeComponentsBuilder;
-
-		let client = VSockHttpClient::new(VsockAddr::new(VSOCK_PROXY_CID, 8000));
-		let components = RuntimeComponentsBuilder::for_tests().build().unwrap();
-
-		counting_connectors(|| {
-			for millis in 0..(MAX_CACHED_CONNECTORS as u64 + 5) {
-				let settings = HttpConnectorSettings::builder()
-					.read_timeout(Duration::from_millis(millis + 1))
-					.build();
-
-				client.http_connector(&settings, &components);
-			}
-		});
+		client.http_connector(&settings, &components);
+		client.http_connector(&settings, &components);
+		client.http_connector(&other, &components);
 
 		assert_eq!(
 			client
@@ -632,7 +551,8 @@ mod tests {
 				.read()
 				.unwrap_or_else(PoisonError::into_inner)
 				.len(),
-			MAX_CACHED_CONNECTORS
+			2,
+			"two distinct timeout configurations, so exactly two connectors"
 		);
 	}
 }

--- a/src/kms.rs
+++ b/src/kms.rs
@@ -38,11 +38,11 @@ use crate::utils::http::{ConnectTimeout, VSockClientBuilder, vsock_proxy_http1};
 /// The CID of the vsock proxy.
 pub const VSOCK_PROXY_CID: u32 = 3;
 
-/// Applied when the caller's `SdkConfig` carries no timeout of its own. Connection timeout.
+/// Default timeout for **connections**
 const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(4);
 /// Timeout on reading the response headers.
 const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(30);
-/// Bounds one attempt end to end.
+/// Total timeout on a requesr
 const DEFAULT_ATTEMPT_TIMEOUT: Duration = Duration::from_mins(1);
 
 /// Credentials to use for KMS requests.
@@ -67,7 +67,7 @@ impl Credentials {
 	}
 }
 
-/// Creates a new KMS client. Re-uses a TLS connection pool, avoid re-creating it.
+/// Creates a new KMS client.
 ///
 /// # Timeouts
 ///
@@ -113,22 +113,15 @@ fn bounded_timeouts(configured: Option<&TimeoutConfig>) -> TimeoutConfig {
 		.build()
 }
 
-/// The connect and read timeouts the orchestrator resolved for a request.
-///
-/// `None` means the caller disabled it. `kms::client` fills in defaults for anything merely unset,
-/// so nothing is re-defaulted here: doing that again would override an explicit `disabled()`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct Timeouts {
+	/// Resolved connection timeout. None = disabled (no limit)
 	connect: Option<Duration>,
+	/// Resolved read timeout. None = disabled (no limit)
 	read: Option<Duration>,
 }
 
-/// Idle connections one connector keeps per upstream authority. hyper-util's default is unbounded,
-/// which an enclave cannot afford.
 const MAX_IDLE_CONNECTIONS: usize = 8;
-
-/// Distinct timeout configurations to cache a connector for. A caller that derives a per-request
-/// timeout from a remaining deadline would otherwise grow this map without bound.
 const MAX_CACHED_CONNECTORS: usize = 8;
 
 /// Routes the AWS SDK's HTTP traffic through the host's vsock proxy.
@@ -151,7 +144,6 @@ impl VSockHttpClient {
 		}
 	}
 
-	/// Once, not once per request: past the cap this fires at the full request rate.
 	fn warn_cache_full(&self) {
 		if !self.cache_full_warned.swap(true, Ordering::Relaxed) {
 			tracing::warn!(
@@ -182,8 +174,6 @@ impl HttpClient for VSockHttpClient {
 			return connector.clone();
 		}
 
-		// Built before taking the write lock: this constructs a rustls `ClientConfig`, and holding
-		// an exclusive lock across that would serialize every concurrent KMS call behind it.
 		let connector = SharedHttpConnector::new(VSockConnector::new(self.address, timeouts));
 		let mut connectors = self
 			.connectors
@@ -282,8 +272,6 @@ async fn await_headers<B>(
 	})
 }
 
-/// Addresses are left unset: a vsock peer has no socket address, and nothing on this path
-/// populates hyper's `HttpInfo`.
 fn connection_metadata(captured: &CaptureConnection) -> Option<ConnectionMetadata> {
 	let proxied = captured.connection_metadata().as_ref()?.is_proxied();
 	let captured = captured.clone();
@@ -429,7 +417,6 @@ mod tests {
 		);
 	}
 
-	/// A caller's own timeout has to win, or configuring one would be pointless.
 	#[test]
 	fn a_configured_timeout_is_not_overridden() {
 		let configured = TimeoutConfig::builder()
@@ -442,7 +429,6 @@ mod tests {
 		assert_eq!(bounded.connect_timeout(), Some(DEFAULT_CONNECT_TIMEOUT));
 	}
 
-	/// `disabled()` is an explicit choice, distinct from leaving a timeout unset.
 	#[test]
 	fn explicitly_disabled_timeouts_stay_disabled() {
 		let bounded = bounded_timeouts(Some(&TimeoutConfig::disabled()));

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -47,9 +47,9 @@ pub fn vsock_proxy_http2(
 	}
 }
 
+/// Provides a TLS connection builder which explicitly rejects non-HTTPs connections. The
+/// host side cannot be considered trusted, so this rejects HTTP-only connections.
 fn tls_builder() -> HttpsConnectorBuilder<hyper_rustls::builderstates::WantsProtocols1> {
-	// Naming the provider avoids rustls' "could not determine the process-level `CryptoProvider`"
-	// panic, which fires whenever something else in the tree also enables `aws_lc_rs`.
 	let config = rustls::ClientConfig::builder_with_provider(Arc::new(
 		rustls::crypto::ring::default_provider(),
 	))
@@ -58,8 +58,6 @@ fn tls_builder() -> HttpsConnectorBuilder<hyper_rustls::builderstates::WantsProt
 	.with_webpki_roots()
 	.with_no_client_auth();
 
-	// `https_only` rather than `https_or_http`: the host-side proxy is untrusted, so an `http://`
-	// URI must fail rather than hand it the request in the clear.
 	HttpsConnectorBuilder::new()
 		.with_tls_config(config)
 		.https_only()
@@ -146,7 +144,7 @@ impl Connection for VSockClient {
 	}
 }
 
-/// Bounds the time a connector may spend establishing a connection.\
+/// Limits the time establishing a connection.
 #[derive(Debug, Clone)]
 pub struct ConnectTimeout<C> {
 	inner: C,


### PR DESCRIPTION
- Improving documentation on the crate from leftover AI output
- Removes cache limit on KMS connectors. The additional complexity is not worth the benefit. As long as the consumer doesn't create thousands of connections all with different timeouts, it'll be fine