### PR TITLE
chore: pin gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,14 @@
 version: 2
 updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+  assignees:
+  - "Takaros999"
+  cooldown:
+    default-days: 14
+
 - package-ecosystem: "cargo"
   directory: "/"
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,13 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
-
-            - uses: dtolnay/rust-toolchain@stable
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
               with:
+                persist-credentials: false
+
+            - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # 2026-08-05
+              with:
+                toolchain: stable
                 components: clippy, rustfmt
 
             - name: Check code formatting
@@ -40,9 +43,13 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+              with:
+                persist-credentials: false
 
-            - uses: dtolnay/rust-toolchain@stable
+            - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # 2026-08-05
+              with:
+                toolchain: stable
 
             - name: Run tests
               run: |
@@ -63,9 +70,11 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+              with:
+                persist-credentials: false
 
-            - uses: EmbarkStudios/cargo-deny-action@v2
+            - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1 https://github.com/EmbarkStudios/cargo-deny-action/releases/tag/v2.1.1
               with:
                   command: check ${{ matrix.checks }}
                   rust-version: stable

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -16,6 +16,6 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1 https://github.com/amannn/action-semantic-pull-request/releases/tag/v6.1.1
     env:
       GITHUB_TOKEN: ${{ github.token }} # granting access only to read pull requests


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI and Dependabot config only; no application runtime changes, with minor workflow behavior shifts (checkout credential persistence and semantic PR action v6).
> 
> **Overview**
> **Pins third-party GitHub Actions to full commit SHAs** (with version comments) instead of floating tags like `@v4` or `@stable`, across `ci.yml` and `validate-pr.yml`. Checkout moves to **v7.0.1** with **`persist-credentials: false`**; **rust-toolchain** is pinned to a specific commit while still requesting **`toolchain: stable`**; **cargo-deny-action** and **semantic-pull-request** are bumped/pinned to documented release SHAs.
> 
> **Adds Dependabot** for the `github-actions` ecosystem (monthly, assignee, 14-day cooldown) so future action updates can be proposed without manually chasing tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90427016b4b0d4ab397c56d08e25bd1cf7c3f432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->