### PR TITLE
fix: cargo trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1


### PR DESCRIPTION
The `id-token` permission is required for GitHub to be able to assume the OIDC role

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow permission scoped to the release job; required for OIDC-based publishing and does not broaden repo write access beyond existing release permissions.
> 
> **Overview**
> **Enables OIDC for the release job** by adding `id-token: write` to the `release-crate` job in `.github/workflows/release.yml`.
> 
> That permission lets GitHub Actions issue an OIDC token so **release-plz / Cargo trusted publishing** can authenticate to crates.io without relying on a stored registry secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a05772c024dcb5b0bf7e4da2117caa743a66358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->